### PR TITLE
Looks like typo in daemonset

### DIFF
--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -17,8 +17,8 @@ spec:
             - /usr/bin/kured
 #          args:
 #            - --alert-filter-regexp=^RebootRequired$
-#            - --ds-name=kube-system
-#            - --ds-namespace=kured
+#            - --ds-name=kured
+#            - --ds-namespace=kube-system
 #            - --lock-annotation=weave.works/kured-node-lock
 #            - --period=1h
 #            - --prometheus-url=http://prometheus.monitoring.svc.cluster.local


### PR DESCRIPTION
Due to 

    metadata:
      name: kured            # Must match `--ds-name`
      namespace: kube-system # Must match `--ds-namespace`

There should be 

    - --ds-name=kured
    - --ds-namespace=kube-system

As args.