### PR TITLE
Update provided manifests to support a service account and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,11 @@ To obtain a default installation without Prometheus alerting interlock
 or Slack notifications:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/weaveworks/kured/master/kured-ds.yaml
+kubectl apply -f https://github.com/weaveworks/kured/releases/download/1.0.0/kured-ds.yaml
 ```
 
 If you want to customise the installation, download the manifest and
 edit it in accordance with the following section before application.
-
-For RBAC support apply the RBAC manifest.
-
-```
-kubectl apply -f https://raw.githubusercontent.com/weaveworks/kured/master/kured-rbac.yaml
-```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,17 @@ To obtain a default installation without Prometheus alerting interlock
 or Slack notifications:
 
 ```
-kubectl apply -f https://github.com/weaveworks/kured/releases/download/1.0.0/kured-ds.yaml
+kubectl apply -f https://raw.githubusercontent.com/weaveworks/kured/master/kured-ds.yaml
 ```
 
 If you want to customise the installation, download the manifest and
 edit it in accordance with the following section before application.
+
+For RBAC support apply the RBAC manifest.
+
+```
+kubectl apply -f https://raw.githubusercontent.com/weaveworks/kured/master/kured-rbac.yaml
+```
 
 ## Configuration
 

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -1,3 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kured
+  namespace: kube-system
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -9,6 +15,7 @@ spec:
       labels:
         name: kured
     spec:
+      serviceAccountName: kured
       containers:
         - name: kured
           image: quay.io/weaveworks/kured

--- a/kured-rbac.yaml
+++ b/kured-rbac.yaml
@@ -1,0 +1,70 @@
+# ClusterRole  
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kured
+rules:
+# Allow kured to grab it's lock
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - update
+# Allow kured to cordon and uncordon nodes
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - update
+# Allow kured to drain nodes
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+---
+# CLusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kured
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kured
+subjects:
+- kind: ServiceAccount
+  name: kured
+  namespace: kube-system

--- a/kured-rbac.yaml
+++ b/kured-rbac.yaml
@@ -1,61 +1,34 @@
-# ClusterRole  
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kured
 rules:
 # Allow kured to grab it's lock
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  verbs:
-  - get
-  - update
+- apiGroups: ["extensions"]
+  resources: ["daemonsets"]
+  verbs:     ["get", "update"]
 # Allow kured to cordon and uncordon nodes
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - update
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs:     ["get", "update"]
 # Allow kured to drain nodes
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - pods/eviction
-  verbs:
-  - create
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["get", "list", "delete"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs:     ["get"]
+- apiGroups: ["extensions"]
+  resources: ["daemonsets", "replicasets"]
+  verbs:     ["get"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs:     ["get"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs:     ["create"]
 ---
-# CLusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/kured-rbac.yaml
+++ b/kured-rbac.yaml
@@ -4,14 +4,21 @@ kind: ClusterRole
 metadata:
   name: kured
 rules:
-# Allow kured to cordon and uncordon nodes
+# Allow kured to read spec.unschedulable
+# Allow kubectl to drain/uncordon
+#
+# NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
+# match https://github.com/kubernetes/kubernetes/blob/v1.9.6/pkg/kubectl/cmd/drain.go
+#
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs:     ["get", "update"]
-# Allow kured to drain nodes
+  verbs:     ["get", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs:     ["get", "list", "delete"]
+  verbs:     ["list"]
+- apiGroups: [""]
+  resources: ["replicationcontrollers"]
+  verbs:     ["get"]
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
   verbs:     ["get"]

--- a/kured-rbac.yaml
+++ b/kured-rbac.yaml
@@ -4,10 +4,6 @@ kind: ClusterRole
 metadata:
   name: kured
 rules:
-# Allow kured to grab it's lock
-- apiGroups: ["extensions"]
-  resources: ["daemonsets"]
-  verbs:     ["get", "update"]
 # Allow kured to cordon and uncordon nodes
 - apiGroups: [""]
   resources: ["nodes"]
@@ -41,3 +37,29 @@ subjects:
 - kind: ServiceAccount
   name: kured
   namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: kured
+rules:
+# Allow kured to lock/unlock itself
+- apiGroups:     ["extensions"]
+  resources:     ["daemonsets"]
+  resourceNames: ["kured"]
+  verbs:         ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: kured
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: kured
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kured


### PR DESCRIPTION
- Added kured service account
- Added kured clusterrole
- Added kured clusterrolebinding
- Updated README.md documentation to include deploying with RBAC support

Thanks to @phsiao and @liggitt who helped point me in the right direction on getting the correct rules for getting the drain working.

## Notes on README changes
I changed the url for the `kubectl apply -f` commands to just point to master as they referenced a release previously which will make maintaining an example deployment easier.  The existing manifests don't specify the image label so if someone were to run the kubectl apply command pointed at the tag/release they would get the latest image and not the version of the binary associated with the tag/release anyhow.  Also with the addition of the `serviceaccount` the manifest in the release won't work with the supplied rbac manifest. 

## Testing done
```
>> kubectl create -f kured-ds.yaml                                                                                                                                        
serviceaccount "kured" created
daemonset "kured" created
```

In CrashLoopBackOff due to lack of RBAC permissions. 

```
>> kubectl get pods -n kube-system -o wide | grep kured
kured-4t7tf                             0/1       CrashLoopBackOff   2          42s       10.233.126.67    k8s-worker-01
kured-cgcng                             0/1       CrashLoopBackOff   2          42s       10.233.93.73     k8s-worker-02
kured-qb2vm                             0/1       CrashLoopBackOff   2          42s       10.233.120.112   k8s-worker-03
```

```
>> kubectl logs -n kube-system kured-qb2vm
time="2017-11-23T16:29:54Z" level=info msg="Kubernetes Reboot Daemon: master-b86c60f" 
time="2017-11-23T16:29:54Z" level=info msg="Node ID: k8s-worker-03" 
time="2017-11-23T16:29:54Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock" 
time="2017-11-23T16:29:54Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 1m0s" 
time="2017-11-23T16:29:54Z" level=fatal msg="Error testing lock: daemonsets.extensions \"kured\" is forbidden: User \"system:serviceaccount:kube-system:kured\" cannot get daemonsets.extensions in the namespace \"kube-system\"" 
```

Apply the RBAC manifest

```
>> kubectl create -f kured-rbac.yaml
clusterrole "kured" created
clusterrolebinding "kured" created
```

Now the pods are now running

```
>> kubectl get pods -n kube-system -o wide | grep kured
kured-4t7tf                             1/1       Running   5          3m        10.233.126.67    k8s-worker-01
kured-cgcng                             1/1       Running   5          3m        10.233.93.73     k8s-worker-02
kured-qb2vm                             1/1       Running   5          3m        10.233.120.112   k8s-worker-03
```

Node running a mix of a replicaset deployment, a few daemonsets, and a statefulset

```
>> kubectl get pods --all-namespaces -o wide | grep worker-03
kube-system   canal-node-c2dbt                        2/2       Running   6          10d       10.4.10.111      k8s-worker-03
kube-system   kube-proxy-gm57k                        1/1       Running   3          8d        10.4.10.111      k8s-worker-03
kube-system   kured-qb2vm                             1/1       Running   5          4m        10.233.120.112   k8s-worker-03
kube-system   nginx-proxy-k8s-worker-03               1/1       Running   3          10d       10.4.10.111      k8s-worker-03
testing       kuard-daemon-tsj99                      1/1       Running   0          7m        10.233.120.101   k8s-worker-03
testing       kuard-deployment-f6b564cff-4sx28        1/1       Running   0          7m        10.233.120.106   k8s-worker-03
testing       kuard-deployment-f6b564cff-82h2g        1/1       Running   0          7m        10.233.120.104   k8s-worker-03
testing       kuard-deployment-f6b564cff-bxsx2        1/1       Running   0          7m        10.233.120.103   k8s-worker-03
testing       kuard-deployment-f6b564cff-j6lm8        1/1       Running   0          7m        10.233.120.102   k8s-worker-03
testing       kuard-deployment-f6b564cff-k7x97        1/1       Running   0          7m        10.233.120.105   k8s-worker-03
testing       kuard-stateful-0                        1/1       Running   0          7m        10.233.120.107   k8s-worker-03
testing       kuard-stateful-10                       1/1       Running   0          7m        10.233.120.111   k8s-worker-03
testing       kuard-stateful-3                        1/1       Running   0          7m        10.233.120.108   k8s-worker-03
testing       kuard-stateful-6                        1/1       Running   0          7m        10.233.120.109   k8s-worker-03
testing       kuard-stateful-9                        1/1       Running   0          7m        10.233.120.110   k8s-worker-03
```

Log output of Kured running and reaction to the touched `/var/run/reboot-required` on k8s-worker-03


```
>> kubectl logs -n kube-system kured-qb2vm                                                                                                                             1 ↵
time="2017-11-23T16:32:08Z" level=info msg="Kubernetes Reboot Daemon: master-b86c60f" 
time="2017-11-23T16:32:08Z" level=info msg="Node ID: k8s-worker-03" 
time="2017-11-23T16:32:08Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock" 
time="2017-11-23T16:32:08Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 1m0s" 
time="2017-11-23T16:33:30Z" level=info msg="Reboot not required" 
time="2017-11-23T16:34:30Z" level=info msg="Reboot not required" 
time="2017-11-23T16:35:30Z" level=info msg="Reboot not required" 
time="2017-11-23T16:36:30Z" level=info msg="Reboot required" 
time="2017-11-23T16:36:30Z" level=info msg="Acquired reboot lock" 
time="2017-11-23T16:36:30Z" level=info msg="Draining node k8s-worker-03" 
time="2017-11-23T16:36:45Z" level=info msg="Commanding reboot" 
```

Log output post reboot

```
>> kubectl logs -n kube-system kured-qb2vm                                                                                                                                
time="2017-11-23T16:37:55Z" level=info msg="Kubernetes Reboot Daemon: master-b86c60f" 
time="2017-11-23T16:37:55Z" level=info msg="Node ID: k8s-worker-03" 
time="2017-11-23T16:37:55Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock" 
time="2017-11-23T16:37:55Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 1m0s" 
time="2017-11-23T16:37:55Z" level=info msg="Holding lock" 
time="2017-11-23T16:37:55Z" level=info msg="Uncordoning node k8s-worker-03" 
time="2017-11-23T16:37:56Z" level=info msg="Releasing lock" 
```

State of the workload on the node post reboot

```
>> kubectl get pods --all-namespaces -o wide | grep worker-03                                                                                                             
kube-system   canal-node-c2dbt                        2/2       Running   8          10d       10.4.10.111      k8s-worker-03
kube-system   kube-proxy-gm57k                        1/1       Running   4          8d        10.4.10.111      k8s-worker-03
kube-system   kured-qb2vm                             1/1       Running   6          10m       10.233.120.114   k8s-worker-03
kube-system   nginx-proxy-k8s-worker-03               1/1       Running   4          10d       10.4.10.111      k8s-worker-03
testing       kuard-daemon-tsj99                      1/1       Running   1          13m       10.233.120.113   k8s-worker-03
```