### PR TITLE
adding option to force reboot, ignoring active allerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ The following arguments can be passed to kured via the daemonset pod template:
 
 ```
 Flags:
-      --alert-filter-regexp value   alert names to ignore when checking for active alerts
-      --ds-name string              namespace containing daemonset on which to place lock (default "kube-system")
-      --ds-namespace string         name of daemonset on which to place lock (default "kured")
-      --lock-annotation string      annotation in which to record locking node (default "weave.works/kured-node-lock")
-      --period duration             reboot check period (default 1h0m0s)
-      --prometheus-url string       Prometheus instance to probe for active alerts
-      --reboot-sentinel string      path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-      --slack-hook-url string       slack hook URL for reboot notfications
-      --slack-username string       slack username for reboot notfications (default "kured")
+      --alert-filter-regexp value    alert names to ignore when checking for active alerts
+      --ds-name string               namespace containing daemonset on which to place lock (default "kube-system")
+      --ds-namespace string          name of daemonset on which to place lock (default "kured")
+      --lock-annotation string       annotation in which to record locking node (default "weave.works/kured-node-lock")
+      --period duration              reboot check period (default 1h0m0s)
+      --prometheus-url string        Prometheus instance to probe for active alerts
+      --reboot-sentinel string       path to file whose existence signals need to reboot (default "/var/run/reboot-required")
+      --force-reboot-sentinel string path to file whose existence signals need to force reboot aka. ignore active prometheus alerts (default "/var/run/force-reboot-required")
+      --slack-hook-url string        slack hook URL for reboot notfications
+      --slack-username string        slack username for reboot notfications (default "kured")
 ```
 
 ### Reboot Sentinel File & Period

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -135,7 +135,7 @@ func rebootRequired() bool {
 
 func rebootBlocked() bool {
 	if forceRebootsentinelExists() {
-		log.Infof("Force reebot sentinel %v exists, force reeboting activated",forceRebootSentinel)
+		log.Infof("Force reboot sentinel %v exists, force rebooting activated",forceRebootSentinel)
 		return false
 	}
 	if prometheusURL != "" {

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -124,7 +124,7 @@ func forceRebootsentinelExists() bool {
 }
 
 func rebootRequired() bool {
-	if sentinelExists() {
+	if sentinelExists() || forceRebootsentinelExists() {
 		log.Infof("Reboot required")
 		return true
 	} else {
@@ -135,7 +135,7 @@ func rebootRequired() bool {
 
 func rebootBlocked() bool {
 	if forceRebootsentinelExists() {
-		log.Infof("Force reboot sentinel %v exists, force rebooting activated",forceRebootSentinel)
+		log.Infof("Force reboot sentinel %v exists, force rebooting activated", forceRebootSentinel)
 		return false
 	}
 	if prometheusURL != "" {


### PR DESCRIPTION
we have a kubernetes cluster running on Azure, sometimes we see high values for softIRQ, we resolve this issue by rebooting the nodes, we want to performe this action even if active prometheus alerts exists. when we see this high values for softIRQ we touches a separate file on the host and the node should restart (despite active alerts exists in prometheus)