### PR TITLE
Parameterise reboot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Flags:
       --annotation-ttl time                  force clean annotation after this ammount of time (default 0, disabled)
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
+      --command string                      systemctl command to run when sentinel is found (default "reboot")
       --ds-name string                      name of daemonset on which to place lock (default "kured")
       --ds-namespace string                 namespace containing daemonset on which to place lock (default "kube-system")
       --end-time string                     only reboot before this time of day (default "23:59")

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -81,7 +81,7 @@ func main() {
 		"alert names to ignore when checking for active alerts")
 	rootCmd.PersistentFlags().StringVar(&rebootSentinel, "reboot-sentinel", "/var/run/reboot-required",
 		"path to file whose existence signals need to run command")
-	rootCmd.PersistentFlags().StringVar(&command, "command", "reboot",
+	rootCmd.PersistentFlags().StringVar(&command, "command", "/bin/systemctl reboot",
 		"systemctl command to run when sentinel is found, default: reboot")
 
 	rootCmd.PersistentFlags().StringVar(&slackHookURL, "slack-hook-url", "",
@@ -270,7 +270,7 @@ func commandReboot(nodeID string) {
 	}
 
 	// Relies on hostPID:true and privileged:true to enter host mount space
-	rebootCmd := newCommand("/usr/bin/nsenter", "-m/proc/1/ns/mnt", "/bin/systemctl", command)
+	rebootCmd := newCommand("/usr/bin/nsenter", "-m/proc/1/ns/mnt", command)
 	if err := rebootCmd.Run(); err != nil {
 		log.Fatalf("Error invoking %s command: %v", command, err)
 	}
@@ -354,13 +354,13 @@ func root(cmd *cobra.Command, args []string) {
 	log.Infof("Lock Annotation: %s/%s:%s", dsNamespace, dsName, lockAnnotation)
 	log.Infof("Reboot Sentinel: %s every %v", rebootSentinel, period)
 	log.Infof("Blocking Pod Selectors: %v", podSelectors)
-	log.Infof("Reboot on: %v", window)
+	log.Infof("Command on: %v", window)
+	log.Infof("Command: %s", command)
 	if annotationTTL > 0 {
 		log.Infof("Force annotation cleanup after: %v", annotationTTL)
 	} else {
 		log.Info("Force annotation cleanup disabled.")
 	}
-	log.Infof("Command: %s", command)
 
 	go rebootAsRequired(nodeID, window, annotationTTL)
 	go maintainRebootRequiredMetric(nodeID)

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -40,6 +40,7 @@ var (
 	slackUsername  string
 	slackChannel   string
 	podSelectors   []string
+	command        string
 
 	rebootDays  []string
 	rebootStart string
@@ -67,7 +68,7 @@ func main() {
 		Run:   root}
 
 	rootCmd.PersistentFlags().DurationVar(&period, "period", time.Minute*60,
-		"reboot check period")
+		"sentinel check period")
 	rootCmd.PersistentFlags().StringVar(&dsNamespace, "ds-namespace", "kube-system",
 		"namespace containing daemonset on which to place lock")
 	rootCmd.PersistentFlags().StringVar(&dsName, "ds-name", "kured",
@@ -79,14 +80,16 @@ func main() {
 	rootCmd.PersistentFlags().Var(&regexpValue{&alertFilter}, "alert-filter-regexp",
 		"alert names to ignore when checking for active alerts")
 	rootCmd.PersistentFlags().StringVar(&rebootSentinel, "reboot-sentinel", "/var/run/reboot-required",
-		"path to file whose existence signals need to reboot")
+		"path to file whose existence signals need to run command")
+	rootCmd.PersistentFlags().StringVar(&command, "command", "reboot",
+		"systemctl command to run when sentinel is found, default: reboot")
 
 	rootCmd.PersistentFlags().StringVar(&slackHookURL, "slack-hook-url", "",
-		"slack hook URL for reboot notfications")
+		"slack hook URL for notfications")
 	rootCmd.PersistentFlags().StringVar(&slackUsername, "slack-username", "kured",
-		"slack username for reboot notfications")
+		"slack username for notfications")
 	rootCmd.PersistentFlags().StringVar(&slackChannel, "slack-channel", "",
-		"slack channel for reboot notfications")
+		"slack channel for notfications")
 
 	rootCmd.PersistentFlags().StringArrayVar(&podSelectors, "blocking-pod-selector", nil,
 		"label selector identifying pods whose presence should prevent reboots")
@@ -258,7 +261,7 @@ func uncordon(nodeID string) {
 }
 
 func commandReboot(nodeID string) {
-	log.Infof("Commanding reboot for node: %s", nodeID)
+	log.Infof("Running command: %s for node: %s", command, nodeID)
 
 	if slackHookURL != "" {
 		if err := slack.NotifyReboot(slackHookURL, slackUsername, slackChannel, nodeID); err != nil {
@@ -267,9 +270,9 @@ func commandReboot(nodeID string) {
 	}
 
 	// Relies on hostPID:true and privileged:true to enter host mount space
-	rebootCmd := newCommand("/usr/bin/nsenter", "-m/proc/1/ns/mnt", "/bin/systemctl", "reboot")
+	rebootCmd := newCommand("/usr/bin/nsenter", "-m/proc/1/ns/mnt", "/bin/systemctl", command)
 	if err := rebootCmd.Run(); err != nil {
-		log.Fatalf("Error invoking reboot command: %v", err)
+		log.Fatalf("Error invoking %s command: %v", command, err)
 	}
 }
 
@@ -357,6 +360,7 @@ func root(cmd *cobra.Command, args []string) {
 	} else {
 		log.Info("Force annotation cleanup disabled.")
 	}
+	log.Infof("Command: %s", command)
 
 	go rebootAsRequired(nodeID, window, annotationTTL)
 	go maintainRebootRequiredMetric(nodeID)


### PR DESCRIPTION
As per #31, it would be useful to shutdown an instance rather than just reboot, for use cases such as cycling instances in an AWS Autoscaling Groups. 

I have tried to keep it simple by just parameterising the `reboot` value as so you can run any of the `systemctl` commands instead. If you have any other suggestions let me know.

Thanks