### PR TITLE
Allow selected pods to prevent reboots

### DIFF
--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -46,6 +46,9 @@ spec:
           command:
             - /usr/bin/kured
 #            - --alert-filter-regexp=^RebootRequired$
+#            - --blocking-pod-selector=runtime=long,cost=expensive
+#            - --blocking-pod-selector=name=temperamental
+#            - --blocking-pod-selector=...
 #            - --ds-name=kured
 #            - --ds-namespace=kube-system
 #            - --lock-annotation=weave.works/kured-node-lock


### PR DESCRIPTION
This PR adds functionality to block individual nodes from rebooting in the presence of specific pods, as determined by a label selector:

```
--blocking-pod-selector=runtime=long,cost=expensive
```

see documentation in the commit for more details.