### PR TITLE
Build arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - deploy:
           name: Build and push image
           command: |
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" quay.io
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             if [ -z "${CIRCLE_TAG}" ]; then
                 make publish-image
             else

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-cmd/kured/kured
+cmd/kured/kured*
 cmd/prom-active-alerts/prom-active-alerts
 vendor
-build
+build*

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,14 @@
+FROM alpine:3.8 as builder
+RUN apk add --no-cache ca-certificates
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/ARCH/kubectl /kubectl
+RUN chmod 0755 /kubectl
+
+FROM BASEIMAGE
+# NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
+COPY --from=builder /kubectl /usr/bin/kubectl
+# Copy certificates
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+# Assume we are in the build directory
+COPY ./kured-ARCH /usr/bin/kured
+ENTRYPOINT ["/usr/bin/kured"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT: all
 .PHONY: all clean image publish-image minikube-publish
 
-DH_ORG="quay.io/weaveworks"
+DH_ORG=quay.io/weaveworks
 VERSION=$(shell git symbolic-ref --short HEAD)-$(shell git rev-parse --short HEAD)
 SUDO=$(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT: all
 .PHONY: all clean image publish-image minikube-publish
 
-DH_ORG=weaveworks
+DH_ORG="quay.io/weaveworks"
 VERSION=$(shell git symbolic-ref --short HEAD)-$(shell git rev-parse --short HEAD)
 SUDO=$(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 
@@ -10,7 +10,7 @@ all: image
 clean:
 	go clean
 	rm -f cmd/kured/kured
-	rm -rf ./build
+	rm -rf ./build*
 
 godeps=$(shell go get $1 && go list -f '{{join .Deps "\n"}}' $1 | grep -v /vendor/ | xargs go list -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}')
 
@@ -20,17 +20,28 @@ cmd/kured/kured: $(DEPS)
 cmd/kured/kured: cmd/kured/*.go
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o $@ cmd/kured/*.go
 
+cmd/kured/kured-arm64: cmd/kured/*.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o $@ cmd/kured/*.go
+
 build/.image.done: cmd/kured/Dockerfile cmd/kured/kured
 	mkdir -p build
 	cp $^ build
-	$(SUDO) docker build -t quay.io/$(DH_ORG)/kured -f build/Dockerfile ./build
-	$(SUDO) docker tag quay.io/$(DH_ORG)/kured quay.io/$(DH_ORG)/kured:$(VERSION)
+	$(SUDO) docker build -t $(DH_ORG)/kured -f build/Dockerfile ./build
+	$(SUDO) docker tag $(DH_ORG)/kured $(DH_ORG)/kured:$(VERSION)
 	touch $@
 
-image: build/.image.done
+build/.image-arm64.done: cmd/kured/Dockerfile.arm64 cmd/kured/kured-arm64
+	mkdir -p build-arm64
+	cp $^ build-arm64
+	$(SUDO) docker build -t $(DH_ORG)/kured-arm64 -f build-arm64/Dockerfile.arm64 ./build-arm64
+	$(SUDO) docker tag $(DH_ORG)/kured-arm64 $(DH_ORG)/kured:$(VERSION)-arm64
+	touch $@
+
+image: build/.image.done build/.image-arm64.done
 
 publish-image: image
-	$(SUDO) docker push quay.io/$(DH_ORG)/kured:$(VERSION)
+	$(SUDO) docker push $(DH_ORG)/kured:$(VERSION)
+	$(SUDO) docker push $(DH_ORG)/kured:$(VERSION)-arm64
 
 minikube-publish: image
-	$(SUDO) docker save quay.io/$(DH_ORG)/kured | (eval $$(minikube docker-env) && docker load)
+	$(SUDO) docker save $(DH_ORG)/kured | (eval $$(minikube docker-env) && docker load)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ or Slack notifications:
 kubectl apply -f https://github.com/weaveworks/kured/releases/download/1.1.0/kured-1.1.0.yaml
 ```
 
+To install on arm64:
+
+```
+curl -sSL https://github.com/weaveworks/kured/releases/download/1.1.0/kured-1.1.0.yaml | sed 's/1.1.0/1.1.0-arm64/g' | kubectl apply -f -
+```
+
 If you want to customise the installation, download the manifest and
 edit it in accordance with the following section before application.
 

--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 # NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubectl /usr/bin/kubectl
 RUN chmod 0755 /usr/bin/kubectl
 COPY ./kured /usr/bin/kured
 ENTRYPOINT ["/usr/bin/kured"]

--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 # NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/amd64/kubectl /usr/bin/kubectl
 RUN chmod 0755 /usr/bin/kubectl
 COPY ./kured /usr/bin/kured
 ENTRYPOINT ["/usr/bin/kured"]

--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:3.8
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
-# NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/amd64/kubectl /usr/bin/kubectl
-RUN chmod 0755 /usr/bin/kubectl
-COPY ./kured /usr/bin/kured
-ENTRYPOINT ["/usr/bin/kured"]

--- a/cmd/kured/Dockerfile.arm64
+++ b/cmd/kured/Dockerfile.arm64
@@ -1,9 +1,0 @@
-FROM alpine:3.8 as fetch-kubectl
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/arm64/kubectl /kubectl
-RUN chmod 0755 /kubectl
-
-FROM arm64v8/alpine:3.8
-# NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
-COPY --from=fetch-kubectl /kubectl /usr/bin/kubectl
-COPY ./kured-arm64 /usr/bin/kured
-ENTRYPOINT ["/usr/bin/kured"]

--- a/cmd/kured/Dockerfile.arm64
+++ b/cmd/kured/Dockerfile.arm64
@@ -1,5 +1,5 @@
 FROM alpine:3.8 as fetch-kubectl
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/arm64/kubectl /kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/arm64/kubectl /kubectl
 RUN chmod 0755 /kubectl
 
 FROM arm64v8/alpine:3.8

--- a/cmd/kured/Dockerfile.arm64
+++ b/cmd/kured/Dockerfile.arm64
@@ -1,0 +1,9 @@
+FROM alpine:3.8 as fetch-kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/arm64/kubectl /kubectl
+RUN chmod 0755 /kubectl
+
+FROM arm64v8/alpine:3.8
+# NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
+COPY --from=fetch-kubectl /kubectl /usr/bin/kubectl
+COPY ./kured-arm64 /usr/bin/kured
+ENTRYPOINT ["/usr/bin/kured"]


### PR DESCRIPTION
* Adds support for building and pushing arm64 Docker images
* Updates kubectl to v1.13.1

Since Quay does not currently support "fat manifests", the images are tagged the same way with the addition of the `-arm64` suffix for the new architecture.

Tested on my Kubernetes 1.13.1 Pine64 cluster.

```
time="2018-12-27T22:48:54Z" level=info msg="Kubernetes Reboot Daemon: build-arm64-114c349"
time="2018-12-27T22:48:54Z" level=info msg="Node ID: kube-node-1"
time="2018-12-27T22:48:54Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock"
time="2018-12-27T22:48:54Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 1h0m0s"
```