### PR TITLE
Add —dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Flags:
       --reboot-sentinel string              path to file whose existence signals need to reboot (default "/var/run/reboot-required")
       --slack-hook-url string               slack hook URL for reboot notfications
       --slack-username string               slack username for reboot notfications (default "kured")
+      --dry-run                             Dry run, do not reboot VMs
 ```
 
 ### Reboot Sentinel File & Period


### PR DESCRIPTION
Enables dry-run where no reboot is triggered (but metrics are published).
Usefull for checking if a cluster (or part of it) needs manual reboots.