### PR TITLE
Adding --annotation-ttl for automatic unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following arguments can be passed to kured via the daemonset pod template:
 
 ```
 Flags:
-      --annotationTTL time                  force clean annotation after this ammount of time (default 0, disabled)
+      --annotation-ttl time                  force clean annotation after this ammount of time (default 0, disabled)
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
       --ds-name string                      name of daemonset on which to place lock (default "kured")
@@ -266,7 +266,7 @@ kubectl -n kube-system annotate ds kured weave.works/kured-node-lock-
 In exceptional circumstances (especially when used with cluster-autoscaler) a node
 which holds lock might be killed thus annotation will stay there for ever.
 
-Using `--annotationTTL=30m` will allow other nodes to take over if TTL has expired (in this case 30min) and continue reboot process.
+Using `--annotation-ttl=30m` will allow other nodes to take over if TTL has expired (in this case 30min) and continue reboot process.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 	* [Testing](#testing)
 	* [Disabling Reboots](#disabling-reboots)
 	* [Manual Unlock](#manual-unlock)
+  * [Automatic Unlock](#automatic-unlock)
 * [Building](#building)
 * [Frequently Asked/Anticipated Questions](#frequently-askedanticipated-questions)
 * [Getting Help](#getting-help)
@@ -46,7 +47,7 @@ compatibility of one minor version between client and server:
 | 1.3.0  | 1.15.10 | v12.0.0          | release-1.15        | 1.15.x, 1.16.x, 1.17.x            |
 | 1.2.0  | 1.13.6  | v10.0.0          | release-1.13        | 1.12.x, 1.13.x, 1.14.x            |
 | 1.1.0  | 1.12.1  | v9.0.0           | release-1.12        | 1.11.x, 1.12.x, 1.13.x            |
-| 1.0.0  | 1.7.6   | v4.0.0           | release-1.7         | 1.6.x, 1.7.x, 1.8.x               | 
+| 1.0.0  | 1.7.6   | v4.0.0           | release-1.7         | 1.6.x, 1.7.x, 1.8.x               |
 
 See the [release notes](https://github.com/weaveworks/kured/releases)
 for specific version compatibility information, including which
@@ -73,6 +74,7 @@ The following arguments can be passed to kured via the daemonset pod template:
 
 ```
 Flags:
+      --annotationTTL time                  force clean annotation after this ammount of time (default 0, disabled)
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
       --ds-name string                      name of daemonset on which to place lock (default "kured")
@@ -258,6 +260,13 @@ kubectl -n kube-system annotate ds kured weave.works/kured-node-lock-
 ```
 > NB the `-` at the end of the command is important - it instructs
 > `kubectl` to remove that annotation entirely.
+
+### Automatic Unlock
+
+In exceptional circumstances (especially when used with cluster-autoscaler) a node
+which holds lock might be killed thus annotation will stay there for ever.
+
+Using `--annotationTTL=30m` will allow other nodes to take over if TTL has expired (in this case 30min) and continue reboot process.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ compatibility of one minor version between client and server:
 | 1.3.0  | 1.15.10 | v12.0.0          | release-1.15        | 1.15.x, 1.16.x, 1.17.x            |
 | 1.2.0  | 1.13.6  | v10.0.0          | release-1.13        | 1.12.x, 1.13.x, 1.14.x            |
 | 1.1.0  | 1.12.1  | v9.0.0           | release-1.12        | 1.11.x, 1.12.x, 1.13.x            |
-| 1.0.0  | 1.7.6   | v4.0.0           | release-1.7         | 1.6.x, 1.7.x, 1.8.x               |
+| 1.0.0  | 1.7.6   | v4.0.0           | release-1.7         | 1.6.x, 1.7.x, 1.8.x               | 
 
 See the [release notes](https://github.com/weaveworks/kured/releases)
 for specific version compatibility information, including which

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -351,7 +351,11 @@ func root(cmd *cobra.Command, args []string) {
 	log.Infof("Reboot Sentinel: %s every %v", rebootSentinel, period)
 	log.Infof("Blocking Pod Selectors: %v", podSelectors)
 	log.Infof("Reboot on: %v", window)
-	log.Infof("Force annotation cleanup after: %v", annotationTTL)
+	if annotationTTL > 0 {
+		log.Info("Force annotation cleanup disabled.")
+	} else {
+		log.Infof("Force annotation cleanup after: %v", annotationTTL)
+	}
 
 	go rebootAsRequired(nodeID, window, annotationTTL)
 	go maintainRebootRequiredMetric(nodeID)

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -99,7 +99,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&timezone, "time-zone", "UTC",
 		"use this timezone for schedule inputs")
 
-	rootCmd.PersistentFlags().DurationVar(&annotationTTL, "annotationTTL", 0,
+	rootCmd.PersistentFlags().DurationVar(&annotationTTL, "annotation-ttl", 0,
 		"force clean annotation after this ammount of time (default 0, disabled)")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -352,9 +352,9 @@ func root(cmd *cobra.Command, args []string) {
 	log.Infof("Blocking Pod Selectors: %v", podSelectors)
 	log.Infof("Reboot on: %v", window)
 	if annotationTTL > 0 {
-		log.Info("Force annotation cleanup disabled.")
-	} else {
 		log.Infof("Force annotation cleanup after: %v", annotationTTL)
+	} else {
+		log.Info("Force annotation cleanup disabled.")
 	}
 
 	go rebootAsRequired(nodeID, window, annotationTTL)

--- a/pkg/daemonsetlock/daemonsetlock.go
+++ b/pkg/daemonsetlock/daemonsetlock.go
@@ -134,7 +134,7 @@ func (dsl *DaemonSetLock) Release() error {
 }
 
 func ttlExpired(created time.Time, ttl time.Duration) bool {
-	if ttl > 0 && time.Now().UTC().Sub(created) >= ttl {
+	if ttl > 0 && time.Since(created) >= ttl {
 		return true
 	}
 	return false

--- a/pkg/daemonsetlock/daemonsetlock.go
+++ b/pkg/daemonsetlock/daemonsetlock.go
@@ -19,15 +19,17 @@ type DaemonSetLock struct {
 }
 
 type lockAnnotationValue struct {
-	NodeID   string      `json:"nodeID"`
-	Metadata interface{} `json:"metadata,omitempty"`
+	NodeID   string        `json:"nodeID"`
+	Metadata interface{}   `json:"metadata,omitempty"`
+	Created  time.Time     `json:"created"`
+	TTL      time.Duration `json:"TTL"`
 }
 
 func New(client *kubernetes.Clientset, nodeID, namespace, name, annotation string) *DaemonSetLock {
 	return &DaemonSetLock{client, nodeID, namespace, name, annotation}
 }
 
-func (dsl *DaemonSetLock) Acquire(metadata interface{}) (acquired bool, owner string, err error) {
+func (dsl *DaemonSetLock) Acquire(metadata interface{}, TTL time.Duration) (acquired bool, owner string, err error) {
 	for {
 		ds, err := dsl.client.AppsV1().DaemonSets(dsl.namespace).Get(dsl.name, metav1.GetOptions{})
 		if err != nil {
@@ -40,13 +42,18 @@ func (dsl *DaemonSetLock) Acquire(metadata interface{}) (acquired bool, owner st
 			if err := json.Unmarshal([]byte(valueString), &value); err != nil {
 				return false, "", err
 			}
+
+			if ttlExpired(value.Created, value.TTL) {
+				return true, value.NodeID, nil
+			}
+
 			return value.NodeID == dsl.nodeID, value.NodeID, nil
 		}
 
 		if ds.ObjectMeta.Annotations == nil {
 			ds.ObjectMeta.Annotations = make(map[string]string)
 		}
-		value := lockAnnotationValue{NodeID: dsl.nodeID, Metadata: metadata}
+		value := lockAnnotationValue{NodeID: dsl.nodeID, Metadata: metadata, Created: time.Now().UTC(), TTL: TTL}
 		valueBytes, err := json.Marshal(&value)
 		if err != nil {
 			return false, "", err
@@ -79,6 +86,11 @@ func (dsl *DaemonSetLock) Test(metadata interface{}) (holding bool, err error) {
 		if err := json.Unmarshal([]byte(valueString), &value); err != nil {
 			return false, err
 		}
+
+		if ttlExpired(value.Created, value.TTL) {
+			return true, nil
+		}
+
 		return value.NodeID == dsl.nodeID, nil
 	}
 
@@ -98,7 +110,7 @@ func (dsl *DaemonSetLock) Release() error {
 			if err := json.Unmarshal([]byte(valueString), &value); err != nil {
 				return err
 			}
-			if value.NodeID != dsl.nodeID {
+			if value.NodeID != dsl.nodeID && !ttlExpired(value.Created, value.TTL) {
 				return fmt.Errorf("Not lock holder: %v", value.NodeID)
 			}
 		} else {
@@ -119,4 +131,11 @@ func (dsl *DaemonSetLock) Release() error {
 		}
 		return nil
 	}
+}
+
+func ttlExpired(created time.Time, ttl time.Duration) bool {
+	if ttl > 0 && time.Now().UTC().Sub(created) >= ttl {
+		return true
+	}
+	return false
 }

--- a/pkg/daemonsetlock/daemonsetlock_test.go
+++ b/pkg/daemonsetlock/daemonsetlock_test.go
@@ -1,0 +1,28 @@
+package daemonsetlock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTtlExpired(t *testing.T) {
+	d := time.Date(2020, 05, 05, 14, 15, 0, 0, time.UTC)
+	second, _ := time.ParseDuration("1s")
+	zero, _ := time.ParseDuration("0m")
+
+	tests := []struct {
+		created time.Time
+		ttl     time.Duration
+		result  bool
+	}{
+		{d, second, true},
+		{time.Now(), second, false},
+		{d, zero, false},
+	}
+
+	for i, tst := range tests {
+		if ttlExpired(tst.created, tst.ttl) != tst.result {
+			t.Errorf("Test %d failed, expected %v but got %v", i, tst.result, !tst.result)
+		}
+	}
+}


### PR DESCRIPTION
I have observed this behavior when running kured together with cluster autoscaler, reason why this idea was born.

- CA adds nodes (CoreOS in my case)
- Nodes are starting to reboot themselves after fetching updates, ie. annotation has been added (lock owned by node 123.123.123.123)
- CA decides to downscale ASG (not all nodes had a chance to reboot yet), and it decides to cut off node 123.123.123.123
- Need to manually take off annotation

This PR introduces `--annotationTTL` parameter, by default set to 0 (means do not use this feature), which allows other kured pods to take off the lock if it has expired.

Comparing kured to [coreos-update-operator](https://github.com/coreos/container-linux-update-operator) latter one is adding lock annotation onto node object which makes such feature as lockTTL completely not required.