### PR TITLE
Update Go version to 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: cimg/go:1.13
     steps:
       - checkout
       - setup_remote_docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weaveworks/kured
 
-go 1.12
+go 1.13
 
 require (
 	github.com/googleapis/gnostic v0.2.0 // indirect


### PR DESCRIPTION
New Go image is recommended in https://circleci.com/docs/2.0/circleci-images/

fixes: #129