### PR TITLE
Unpin base docker image

### DIFF
--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.3
+FROM alpine:3.11
 RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 # NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl /usr/bin/kubectl


### PR DESCRIPTION
The upside is that image building will always use the latest
stable version of the alpine OS, which might include security fixes.
The downside is that it's less reproducible, because the full
version isn't given.

While this commit isn't necessary per se, it's nice to have
an image that will be up to date, when we'll build it.