### PR TITLE
print the node id when commanding a reboot

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -253,7 +253,7 @@ func uncordon(nodeID string) {
 }
 
 func commandReboot(nodeID string) {
-	log.Infof("Commanding reboot")
+	log.Infof("Commanding reboot for node: %s", nodeID)
 
 	if slackHookURL != "" {
 		if err := slack.NotifyReboot(slackHookURL, slackUsername, slackChannel, nodeID); err != nil {


### PR DESCRIPTION
Before commanding a reboot, it would be good if the node id is printed.
In the cloud, this could be taken by any centralized monitoring tool, and trigger some actions.
For example: On Azure, Azure Monitor could get this log, send notifications
Another use case is being able to query this together with applications logs when troubleshooting