### PR TITLE
Don't run Circle CI on gh-pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+jobs:
+  build:
+    machine: true
+    steps:
+      - run: "echo skip"
+
+workflows:
+  version: 2
+  ignore:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - gh-pages


### PR DESCRIPTION
Follow the lead of https://github.com/weaveworks/flagger/blob/gh-pages/.circleci/config.yml