### PR TITLE
Remove quote for parameter alert-filter-regexp

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.0"
 description: A Helm chart for kured
 name: kured
-version: 2.2.0
+version: 2.2.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
             - --annotation-ttl={{ .Values.configuration.annotationTtl }}
           {{- end }}
           {{- if .Values.configuration.alertFilterRegexp }}
-            - --alert-filter-regexp={{ .Values.configuration.alertFilterRegexp | quote }}
+            - --alert-filter-regexp={{ .Values.configuration.alertFilterRegexp }}
           {{- end }}
           {{- range .Values.configuration.blockingPodSelector }}
             - --blocking-pod-selector={{ . }}


### PR DESCRIPTION
The Helm chart config option alertFilterRegexp does not work with quotes in the most recent version 2.0.3.

When using

```
configuration:
  alertFilterRegexp: ^(Watchdog)$
```

as configuration option, the reboot is blocked, because the regexp is interpreted as `"^(Watchdog)$"` (yes, including the quotes).

```
time="2020-07-04T20:32:31Z" level=info msg="Kubernetes Reboot Daemon: 1.4.4"
time="2020-07-04T20:32:31Z" level=info msg="Node ID: xxx"
time="2020-07-04T20:32:31Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock"
time="2020-07-04T20:32:31Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 1m0s"
time="2020-07-04T20:32:31Z" level=info msg="Blocking Pod Selectors: []"
time="2020-07-04T20:32:31Z" level=info msg="Reboot on: SunMonTueWedThuFriSat between 00:00 and 23:59 Europe/Berlin"
time="2020-07-04T20:32:31Z" level=info msg="Force annotation cleanup disabled."
time="2020-07-04T20:33:57Z" level=info msg="Reboot required"
time="2020-07-04T20:33:57Z" level=warning msg="Reboot blocked: 1 active alerts: [Watchdog]"
```

This PR removes the quotes for the parameter `alert-filter-regexp`.