### PR TITLE
Chart: Support extraEnvVars

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.4"
 description: A Helm chart for kured
 name: kured
-version: 2.0.3
+version: 2.1.0
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: dholbach

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -42,6 +42,7 @@ The following changes have been made compared to the stable chart:
 | `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |
 | `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
+| `extraEnvVars`          | Array of environment variables to pass to the daemonset.                    | `{}`                       |
 | `configuration.annotationTtl` | cli-parameter `--annotation-ttl`                                      | `0`                       |
 | `configuration.alertFilterRegexp` | cli-parameter `--alert-filter-regexp`                             | `""`                       |
 | `configuration.blockingPodSelector` | Array of selectors for multiple cli-parameters `--blocking-pod-selector` | `[]`             |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -106,6 +106,7 @@ spec:
                   fieldPath: spec.nodeName
             {{- if .Values.extraEnvVars }}
               {{ toYaml .Values.extraEnvVars | indent 12 }}
+            {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -104,6 +104,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.extraEnvVars }}
+              {{ toYaml .Values.extraEnvVars | indent 12 }}
       {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -105,7 +105,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             {{- if .Values.extraEnvVars }}
-              {{ toYaml .Values.extraEnvVars | indent 12 }}
+              {{ toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -10,6 +10,15 @@ podAnnotations: {}
 
 extraArgs: {}
 
+extraEnvVars:
+#  - name: slackHookUrl
+#    valueFrom:
+#      secretKeyRef:
+#        name: secret_name
+#        key: secret_key
+#  - name: regularEnvVariable
+#    value: 123
+
 configuration:
   annotationTtl: 0          # force clean annotation after this ammount of time (default 0, disabled)
   alertFilterRegexp: ""     # alert names to ignore when checking for active alerts


### PR DESCRIPTION
See issue #167

It seems to me that extraArgs does not support my use-case. 
Support setting extraEnvs so that extraArgs can refer to env variables such as $slackHookUrl