### PR TITLE
fix: Follow DKL-DI-0004 guideline

### DIFF
--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.12
-RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache ca-certificates tzdata
 # NB: you may need to update RBAC permissions when upgrading kubectl - see kured-rbac.yaml for details
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.18.8/bin/linux/amd64/kubectl /usr/bin/kubectl
 RUN chmod 0755 /usr/bin/kubectl


### PR DESCRIPTION
Without this patch, we need to build a cache and remove it
afterwards.  Since apk allows to work with no-cache and won't
leave artifacts, we should use it.

This will make the dockle best practices scanner happier.