### PR TITLE
feat: Add security scanning into CI

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,7 @@
+general:
+  bestPracticeViolations:
+    # We violate this rule because we add kubectl from a remote location
+    # Instead of building it from source/copying it.
+    # Until we change our practices (e.g. have Dockerfile build kubectl
+    # in a multi-staged manner), we should skip this check
+    - CIS-DI-0009

--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -1,0 +1,14 @@
+# This should not be made a mandatory test
+# It is only used to make us aware of any potential security failure, that
+# should trigger a bump of the image in build/.
+name: "Image vulnerability scan"
+on: [push, pull_request]
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
+      - uses: Azure/container-scan@v0
+        with:
+          image-name: docker.io/${{ github.repository_owner }}/kured:${{ github.sha }}


### PR DESCRIPTION
Without this patch, there is no way we can see, in the development
process, if the image we are about to publish is insecure.

This is a problem as we might be releasing new versions of kured
with outdated base image which contains vulnerabilities.

This fixes it by creating a job which will show any eventual
vulnerability.