### PR TITLE
Added support for time wrap in timewindow.Contains

### DIFF
--- a/pkg/timewindow/timewindow.go
+++ b/pkg/timewindow/timewindow.go
@@ -47,6 +47,19 @@ func (tw *TimeWindow) Contains(t time.Time) bool {
 	start := time.Date(loctime.Year(), loctime.Month(), loctime.Day(), tw.startTime.Hour(), tw.startTime.Minute(), tw.startTime.Second(), 0, tw.location)
 	end := time.Date(loctime.Year(), loctime.Month(), loctime.Day(), tw.endTime.Hour(), tw.endTime.Minute(), tw.endTime.Second(), 1e9-1, tw.location)
 
+	// Time Wrap validation
+	// First we check for start and end time, if start is after end time
+	// Next we need to validate if we want to wrap to the day before or to the day after
+	// For that we check the loctime value to see if it is before end time, we wrap with the day before
+	// Otherwise we wrap to the next day.
+	if tw.startTime.After(tw.endTime) {
+		if loctime.Before(end) {
+			start = start.Add(-24 * time.Hour)
+		} else {
+			end = end.Add(24 * time.Hour)
+		}
+	}
+
 	return (loctime.After(start) || loctime.Equal(start)) && (loctime.Before(end) || loctime.Equal(end))
 }
 

--- a/pkg/timewindow/timewindow_test.go
+++ b/pkg/timewindow/timewindow_test.go
@@ -20,12 +20,12 @@ func TestTimeWindows(t *testing.T) {
 		cases []testcase
 	}{
 		{"mon,tue,wed,thu,fri", "9am", "5pm", "America/Los_Angeles", []testcase{
-			{"2019/04/04 00:49 PDT", false},
-			{"2019/04/05 08:59 PDT", false},
-			{"2019/04/05 9:01 PDT", true},
 			{"2019/03/31 10:00 PDT", false},
+			{"2019/04/04 00:49 PDT", false},
 			{"2019/04/04 12:00 PDT", true},
 			{"2019/04/04 11:59 UTC", false},
+			{"2019/04/05 08:59 PDT", false},
+			{"2019/04/05 9:01 PDT", true},
 		}},
 		{"mon,we,fri", "10:01", "11:30am", "America/Los_Angeles", []testcase{
 			{"2019/04/05 10:30 PDT", true},
@@ -39,6 +39,43 @@ func TestTimeWindows(t *testing.T) {
 		{"mo,tu,we,th,fr", "00:00", "23:59:59", "UTC", []testcase{
 			{"2019/04/18 00:00 UTC", true},
 			{"2019/04/18 23:59 UTC", true},
+		}},
+		{"mon,tue,wed,thu,fri", "9pm", "5am", "America/Los_Angeles", []testcase{
+			{"2019/03/30 04:00 PDT", false},
+			{"2019/03/31 10:00 PDT", false},
+			{"2019/03/31 22:00 PDT", false},
+			{"2019/04/04 00:49 PDT", true},
+			{"2019/04/04 12:00 PDT", false},
+			{"2019/04/04 22:49 PDT", true},
+			{"2019/04/05 00:49 PDT", true},
+			{"2019/04/05 08:59 PDT", false},
+			{"2019/04/05 9:01 PDT", false},
+		}},
+		{"mon,tue,wed,thu,fri", "11:59pm", "00:01am", "America/Los_Angeles", []testcase{
+			{"2019/04/04 23:58 PDT", false},
+			{"2019/04/04 23:59 PDT", true},
+			{"2019/04/05 00:00 PDT", true},
+			{"2019/04/05 00:01 PDT", true},
+			{"2019/04/05 00:02 PDT", false},
+		}},
+		{"mon,tue,wed,fri", "11:59pm", "00:01am", "America/Los_Angeles", []testcase{
+			{"2019/04/04 23:58 PDT", false},
+			{"2019/04/04 23:59 PDT", false}, // Even that this falls in the between the hours Thursday is not included so should not run
+			{"2019/04/05 00:00 PDT", true},
+			{"2019/04/05 00:02 PDT", false},
+		}},
+		{"mon,tue,wed,thu", "11:59pm", "00:01am", "America/Los_Angeles", []testcase{
+			{"2019/04/04 23:58 PDT", false},
+			{"2019/04/04 23:59 PDT", true},
+			{"2019/04/05 00:00 PDT", false}, // Even that this falls in the between the hours Friday is not included so should not run
+			{"2019/04/05 00:02 PDT", false},
+		}},
+		{"mon,tue,wed,thu,fri", "11:59pm", "00:01am", "UTC", []testcase{
+			{"2019/04/04 23:58 UTC", false},
+			{"2019/04/04 23:59 UTC", true},
+			{"2019/04/05 00:00 UTC", true},
+			{"2019/04/05 00:01 UTC", true},
+			{"2019/04/05 00:02 UTC", false},
 		}},
 	}
 


### PR DESCRIPTION
Time Wrap validation

As stated in the issue #204 it is not possible to time wrap rules. For that we need to add the logic that will adhere to those scenarios.

First we check for start and end time, if start is after end time, we need to validate if we want to wrap to the day before or to the day after.

For that we check the `loctime` value to see if it is before end time, we wrap with the day before, otherwise we wrap to the next day.

I added suggested test scenarios and others that check for a time wrap with not valid days.

fixes #204 