### PR TITLE
Implement universal notification mechanism using shoutrrr

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ Alternatively you can use the `--message-template-drain` and `--message-template
 --message-template-drain="Draining node %s part of *my-cluster* in region *xyz*"
 ```
 
+### Notifications 
+
+When you specify a formatted URL using `--notify-url`, kured will notify
+about draining and rebooting nodes across a list of technologies. Here is 
+the syntax:
+
+slack:           `slack://tokenA/tokenB/tokenC`
+
+rocketchat:      `rocketchat://[username@]rocketchat-host/token[/channel|@recipient]`
+
+teams:           `teams://token-a/token-b/token-c`
+
+Email:           `smtp://username:password@host:port/?fromAddress=fromAddress&toAddresses=recipient1[,recipient2,...]`
+
+More details here: https://github.com/containrrr/shoutrrr/blob/master/docs/services/overview.md
+
 ### Overriding Lock Configuration
 
 The `--ds-name` and `--ds-namespace` arguments should match the name and

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaveworks/kured/pkg/delaytick"
 	"github.com/weaveworks/kured/pkg/notifications/slack"
 	"github.com/weaveworks/kured/pkg/timewindow"
+	shoutrrr "github.com/containrrr/shoutrrr"
 )
 
 var (
@@ -41,11 +42,11 @@ var (
 	rebootSentinel         string
 	slackHookURL           string
 	slackUsername          string
+	notifyURL              string
 	slackChannel           string
 	messageTemplateDrain   string
 	messageTemplateReboot  string
 	podSelectors           []string
-
 	rebootDays  []string
 	rebootStart string
 	rebootEnd   string
@@ -67,6 +68,7 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "kured",
 		Short: "Kubernetes Reboot Daemon",
+		PreRun: flagCheck,
 		Run:   root}
 
 	rootCmd.PersistentFlags().DurationVar(&period, "period", time.Minute*60,
@@ -92,6 +94,8 @@ func main() {
 		"slack username for reboot notfications")
 	rootCmd.PersistentFlags().StringVar(&slackChannel, "slack-channel", "",
 		"slack channel for reboot notfications")
+	rootCmd.PersistentFlags().StringVar(&notifyURL, "notify-url", "",
+		"notify URL for reboot notfications")
 	rootCmd.PersistentFlags().StringVar(&messageTemplateDrain, "message-template-drain", "Draining node %s",
 		"message template used to notify about a node being drained")
 	rootCmd.PersistentFlags().StringVar(&messageTemplateReboot, "message-template-reboot", "Rebooting node %s",
@@ -112,6 +116,18 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// temporary func that checks for deprecated slack-notification-related flags
+func flagCheck(cmd *cobra.Command, args []string) {
+	if slackHookURL != "" && notifyURL != "" {
+		log.Warnf("Cannot use both --notify-url and --slack-hook-url flags. Kured will use --notify-url flag only...")
+		slackHookURL = ""
+	}
+	if slackChannel != "" || slackHookURL != "" || slackUsername != "" {
+		log.Warnf("Deprecated flag(s). Please use --notify-url flag instead.")
+	}
+
 }
 
 // newCommand creates a new Command with stdout/stderr wired to our standard logger
@@ -247,6 +263,12 @@ func drain(client *kubernetes.Clientset, node *v1.Node) {
 			log.Warnf("Error notifying slack: %v", err)
 		}
 	}
+	if notifyURL != "" {
+		if err := shoutrrr.Send(notifyURL, fmt.Sprintf(messageTemplateDrain, nodename)); err != nil {
+			log.Warnf("Error notifying: %v", err)
+		}
+	}
+
 
 	drainer := &kubectldrain.Helper{
 		Client:              client,
@@ -285,6 +307,11 @@ func commandReboot(nodeID string) {
 	if slackHookURL != "" {
 		if err := slack.NotifyReboot(slackHookURL, slackUsername, slackChannel, messageTemplateReboot, nodeID); err != nil {
 			log.Warnf("Error notifying slack: %v", err)
+		}
+	}
+	if notifyURL != "" {
+		if err := shoutrrr.Send(notifyURL, fmt.Sprintf(messageTemplateReboot, nodeID)); err != nil {
+			log.Warnf("Error notifying: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/weaveworks/kured/issues/117
Closes https://github.com/weaveworks/kured/issues/94
This PR doesn't interfere with the slack-notification logic that is in place.
Instead of using only slack-related args, one can pass to kured flags:
- --notify-url=<URL link that follows this syntax as f(chat tech solution): https://containrrr.dev/shoutrrr/services/overview/>


So far, I've tested it on SUSE CaaSP 4.2 with k8s 1.17, on vmware.  I've tested rocketchat. It worked as it should. Further this functionality can be more ellaborated, specifying (may be depending on a --verbosity  input) for each situation (like draining, cordoning, reboot and so on). 