### PR TITLE
Drain: allow pods grace period to terminate

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -244,6 +244,7 @@ func drain(client *kubernetes.Clientset, node *v1.Node) {
 
 	drainer := &kubectldrain.Helper{
 		Client:              client,
+		GracePeriodSeconds:  -1,
 		Force:               true,
 		DeleteLocalData:     true,
 		IgnoreAllDaemonSets: true,


### PR DESCRIPTION
The default of 0 is taken as "delete immediately", which is not appropriate.

Fixes #236 