### PR TITLE
rename annotation-ttl to lock-ttl in all places, follow-up to #213

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following arguments can be passed to kured via the daemonset pod template:
 
 ```console
 Flags:
-      --annotation-ttl time                  force clean annotation after this ammount of time (default 0, disabled)
+      --lock-ttl time                       force clean annotation after this ammount of time (default 0, disabled)
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
       --ds-name string                      name of daemonset on which to place lock (default "kured")
@@ -272,7 +272,7 @@ kubectl -n kube-system annotate ds kured weave.works/kured-node-lock-
 In exceptional circumstances (especially when used with cluster-autoscaler) a node
 which holds lock might be killed thus annotation will stay there for ever.
 
-Using `--annotation-ttl=30m` will allow other nodes to take over if TTL has expired (in this case 30min) and continue reboot process.
+Using `--lock-ttl=30m` will allow other nodes to take over if TTL has expired (in this case 30min) and continue reboot process.
 
 ## Building
 

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -43,7 +43,7 @@ The following changes have been made compared to the stable chart:
 | `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
 | `extraEnvVars`          | Array of environment variables to pass to the daemonset.                    | `{}`                       |
-| `configuration.annotationTtl` | cli-parameter `--annotation-ttl`                                      | `0`                       |
+| `configuration.lockTtl` | cli-parameter `--lock-ttl`                                                  | `0`                       |
 | `configuration.alertFilterRegexp` | cli-parameter `--alert-filter-regexp`                             | `""`                       |
 | `configuration.blockingPodSelector` | Array of selectors for multiple cli-parameters `--blocking-pod-selector` | `[]`             |
 | `configuration.endTime` | cli-parameter `--end-time`                                                  | `""`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -45,8 +45,8 @@ spec:
           args:
             - --ds-name={{ template "kured.fullname" . }}
             - --ds-namespace={{ .Release.Namespace }}
-          {{- if .Values.configuration.annotationTtl }}
-            - --annotation-ttl={{ .Values.configuration.annotationTtl }}
+          {{- if .Values.configuration.lockTtl }}
+            - --lock-ttl={{ .Values.configuration.lockTtl }}
           {{- end }}
           {{- if .Values.configuration.alertFilterRegexp }}
             - --alert-filter-regexp={{ .Values.configuration.alertFilterRegexp }}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -20,7 +20,7 @@ extraEnvVars:
 #    value: 123
 
 configuration:
-  annotationTtl: 0          # force clean annotation after this ammount of time (default 0, disabled)
+  lockTtl: 0                # force clean annotation after this ammount of time (default 0, disabled)
   alertFilterRegexp: ""     # alert names to ignore when checking for active alerts
   blockingPodSelector: []   # label selector identifying pods whose presence should prevent reboots
   endTime: ""               # only reboot before this time of day (default "23:59")


### PR DESCRIPTION
The command-line option was changed in #213 and needed to be updated in the chart and docs.