### PR TITLE
implement issue-19 add prefer no schedule taint to avoid double draining of pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Flags:
       --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
       --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
       --period duration                     reboot check period (default 1h0m0s)
-      --prefer-no-schedule-taint string     Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Set to "" to disable tainting. (default "weave.works/kured-node-reboot")
+      --prefer-no-schedule-taint string     Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to "weave.works/kured-node-reboot" to enable tainting.
       --prometheus-url string               Prometheus instance to probe for active alerts
       --reboot-days strings                 schedule reboot on these days (default [su,mo,tu,we,th,fr,sa])
       --reboot-sentinel string              path to file whose existence signals need to reboot (default "/var/run/reboot-required")
@@ -99,7 +99,6 @@ Flags:
       --slack-username string               slack username for reboot notfications (default "kured")
       --start-time string                   schedule reboot only after this time of day (default "0:00")
       --time-zone string                    use this timezone for schedule inputs (default "UTC")
-
 ```
 
 ### Reboot Sentinel File & Period

--- a/README.md
+++ b/README.md
@@ -79,25 +79,27 @@ The following arguments can be passed to kured via the daemonset pod template:
 
 ```console
 Flags:
-      --lock-ttl time                       force clean annotation after this ammount of time (default 0, disabled)
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
       --ds-name string                      name of daemonset on which to place lock (default "kured")
       --ds-namespace string                 namespace containing daemonset on which to place lock (default "kube-system")
-      --end-time string                     only reboot before this time of day (default "23:59")
+      --end-time string                     schedule reboot only before this time of day (default "23:59:59")
   -h, --help                                help for kured
       --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
+      --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
+      --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
+      --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
       --period duration                     reboot check period (default 1h0m0s)
+      --prefer-no-schedule-taint string     Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Set to "" to disable tainting. (default "weave.works/kured-node-reboot")
       --prometheus-url string               Prometheus instance to probe for active alerts
-      --reboot-days strings                 only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+      --reboot-days strings                 schedule reboot on these days (default [su,mo,tu,we,th,fr,sa])
       --reboot-sentinel string              path to file whose existence signals need to reboot (default "/var/run/reboot-required")
       --slack-channel string                slack channel for reboot notfications
       --slack-hook-url string               slack hook URL for reboot notfications
       --slack-username string               slack username for reboot notfications (default "kured")
-      --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
-      --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
-      --start-time string                   only reboot after this time of day (default "0:00")
-      --time-zone string                    use this timezone to calculate allowed reboot time (default "UTC")
+      --start-time string                   schedule reboot only after this time of day (default "0:00")
+      --time-zone string                    use this timezone for schedule inputs (default "UTC")
+
 ```
 
 ### Reboot Sentinel File & Period

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -87,8 +87,8 @@ func main() {
 		"alert names to ignore when checking for active alerts")
 	rootCmd.PersistentFlags().StringVar(&rebootSentinel, "reboot-sentinel", "/var/run/reboot-required",
 		"path to file whose existence signals need to reboot")
-	rootCmd.PersistentFlags().StringVar(&preferNoScheduleTaintName, "prefer-no-schedule-taint", "weave.works/kured-node-reboot",
-		"Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Set to \"\" to disable tainting.")
+	rootCmd.PersistentFlags().StringVar(&preferNoScheduleTaintName, "prefer-no-schedule-taint", "",
+		"Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to \"weave.works/kured-node-reboot\" to enable tainting.")
 
 	rootCmd.PersistentFlags().StringVar(&slackHookURL, "slack-hook-url", "",
 		"slack hook URL for reboot notfications")

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -88,7 +88,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&rebootSentinel, "reboot-sentinel", "/var/run/reboot-required",
 		"path to file whose existence signals need to reboot")
 	rootCmd.PersistentFlags().StringVar(&preferNoScheduleTaintName, "prefer-no-schedule-taint", "weave.works/kured-node-reboot",
-		"taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes)")
+		"Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Set to \"\" to disable tainting.")
 
 	rootCmd.PersistentFlags().StringVar(&slackHookURL, "slack-hook-url", "",
 		"slack hook URL for reboot notfications")

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -258,11 +258,11 @@ func drain(client *kubernetes.Clientset, node *v1.Node) {
 		Out:                 os.Stdout,
 	}
 	if err := kubectldrain.RunCordonOrUncordon(drainer, node, true); err != nil {
-		log.Fatal("Error cordonning %s: %v", nodename, err)
+		log.Fatalf("Error cordonning %s: %v", nodename, err)
 	}
 
 	if err := kubectldrain.RunNodeDrain(drainer, nodename); err != nil {
-		log.Fatal("Error draining %s: %v", nodename, err)
+		log.Fatalf("Error draining %s: %v", nodename, err)
 	}
 }
 
@@ -275,7 +275,7 @@ func uncordon(client *kubernetes.Clientset, node *v1.Node) {
 		Out:    os.Stdout,
 	}
 	if err := kubectldrain.RunCordonOrUncordon(drainer, node, false); err != nil {
-		log.Fatal("Error uncordonning %s: %v", nodename, err)
+		log.Fatalf("Error uncordonning %s: %v", nodename, err)
 	}
 }
 

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -357,6 +357,7 @@ func rebootAsRequired(nodeID string, window *timewindow.TimeWindow, TTL time.Dur
 		}
 
 		if !rebootRequired() {
+			preferNoScheduleTaint.Disable()
 			continue
 		}
 

--- a/pkg/taints/taints.go
+++ b/pkg/taints/taints.go
@@ -1,0 +1,140 @@
+package taints
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Taint allows to set soft and hard limitations for scheduling and executing pods on nodes.
+type Taint struct {
+	client    *kubernetes.Clientset
+	nodeID    string
+	taintName string
+	effect    v1.TaintEffect
+}
+
+// New provides a new taint.
+func New(client *kubernetes.Clientset, nodeID, taintName string, effect v1.TaintEffect) *Taint {
+	return &Taint{
+		client:    client,
+		nodeID:    nodeID,
+		taintName: taintName,
+		effect:    effect,
+	}
+}
+
+// Enable creates the taint for a node. Creating an existing taint is a noop.
+func (t *Taint) Enable() {
+	preferNoSchedule(t.client, t.nodeID, t.taintName, t.effect, true)
+}
+
+// Disable removes the taint for a node. Removing a missing taint is a noop.
+func (t *Taint) Disable() {
+	preferNoSchedule(t.client, t.nodeID, t.taintName, t.effect, false)
+}
+
+func preferNoSchedule(client *kubernetes.Clientset, nodeID, taintName string, effect v1.TaintEffect, taintShouldExists bool) {
+	updatedNode, err := client.CoreV1().Nodes().Get(context.TODO(), nodeID, metav1.GetOptions{})
+	if err != nil || updatedNode == nil {
+		log.Fatalf("Error reading node %s: %v", nodeID, err)
+	}
+
+	taintExists := false
+	offset := 0
+	for i, taint := range updatedNode.Spec.Taints {
+		if taint.Key == taintName {
+			taintExists = true
+			offset = i
+			break
+		}
+	}
+
+	if taintExists && taintShouldExists {
+		log.Debugf("Taint %v exists already for node %v.", taintName, nodeID)
+		return
+	}
+
+	if !taintExists && !taintShouldExists {
+		log.Debugf("Taint %v already missing for node %v.", taintName, nodeID)
+		return
+	}
+
+	type patchTaints struct {
+		Op    string      `json:"op"`
+		Path  string      `json:"path"`
+		Value interface{} `json:"value,omitempty"`
+	}
+
+	taint := v1.Taint{
+		Key:    taintName,
+		Effect: effect,
+	}
+
+	var patches []patchTaints
+
+	if len(updatedNode.Spec.Taints) == 0 {
+		// add first taint and ensure to keep current taints
+		patches = []patchTaints{
+			{
+				Op:    "test",
+				Path:  "/spec",
+				Value: updatedNode.Spec,
+			},
+			{
+				Op:    "add",
+				Path:  "/spec/taints",
+				Value: []v1.Taint{},
+			},
+			{
+				Op:    "add",
+				Path:  "/spec/taints/-",
+				Value: taint,
+			},
+		}
+	} else if taintExists {
+		// remove taint and ensure to test against race conditions
+		patches = []patchTaints{
+			{
+				Op:    "test",
+				Path:  fmt.Sprintf("/spec/taints/%d", offset),
+				Value: taint,
+			},
+			{
+				Op:   "remove",
+				Path: fmt.Sprintf("/spec/taints/%d", offset),
+			},
+		}
+	} else {
+		// add missing taint to exsting list
+		patches = []patchTaints{
+			{
+				Op:    "add",
+				Path:  "/spec/taints/-",
+				Value: taint,
+			},
+		}
+	}
+
+	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		log.Fatalf("Error encoding taint patcht for node %s: %v", nodeID, err)
+	}
+
+	_, err = client.CoreV1().Nodes().Patch(context.TODO(), nodeID, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		log.Fatalf("Error patching taint for node %s: %v", nodeID, err)
+	}
+
+	if taintShouldExists {
+		log.Info("Node taint added")
+	} else {
+		log.Info("Node taint removed")
+	}
+}

--- a/pkg/taints/taints.go
+++ b/pkg/taints/taints.go
@@ -40,7 +40,7 @@ func (t *Taint) Disable() {
 	preferNoSchedule(t.client, t.nodeID, t.taintName, t.effect, false)
 }
 
-func preferNoSchedule(client *kubernetes.Clientset, nodeID, taintName string, effect v1.TaintEffect, taintShouldExists bool) {
+func preferNoSchedule(client *kubernetes.Clientset, nodeID, taintName string, effect v1.TaintEffect, shouldExists bool) {
 	updatedNode, err := client.CoreV1().Nodes().Get(context.TODO(), nodeID, metav1.GetOptions{})
 	if err != nil || updatedNode == nil {
 		log.Fatalf("Error reading node %s: %v", nodeID, err)
@@ -56,12 +56,12 @@ func preferNoSchedule(client *kubernetes.Clientset, nodeID, taintName string, ef
 		}
 	}
 
-	if taintExists && taintShouldExists {
+	if taintExists && shouldExists {
 		log.Debugf("Taint %v exists already for node %v.", taintName, nodeID)
 		return
 	}
 
-	if !taintExists && !taintShouldExists {
+	if !taintExists && !shouldExists {
 		log.Debugf("Taint %v already missing for node %v.", taintName, nodeID)
 		return
 	}
@@ -124,7 +124,7 @@ func preferNoSchedule(client *kubernetes.Clientset, nodeID, taintName string, ef
 
 	patchBytes, err := json.Marshal(patches)
 	if err != nil {
-		log.Fatalf("Error encoding taint patcht for node %s: %v", nodeID, err)
+		log.Fatalf("Error encoding taint patch for node %s: %v", nodeID, err)
 	}
 
 	_, err = client.CoreV1().Nodes().Patch(context.TODO(), nodeID, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
@@ -132,7 +132,7 @@ func preferNoSchedule(client *kubernetes.Clientset, nodeID, taintName string, ef
 		log.Fatalf("Error patching taint for node %s: %v", nodeID, err)
 	}
 
-	if taintShouldExists {
+	if shouldExists {
 		log.Info("Node taint added")
 	} else {
 		log.Info("Node taint removed")

--- a/pkg/taints/taints.go
+++ b/pkg/taints/taints.go
@@ -32,11 +32,19 @@ func New(client *kubernetes.Clientset, nodeID, taintName string, effect v1.Taint
 
 // Enable creates the taint for a node. Creating an existing taint is a noop.
 func (t *Taint) Enable() {
+	if t.taintName == "" {
+		return
+	}
+
 	preferNoSchedule(t.client, t.nodeID, t.taintName, t.effect, true)
 }
 
 // Disable removes the taint for a node. Removing a missing taint is a noop.
 func (t *Taint) Disable() {
+	if t.taintName == "" {
+		return
+	}
+
 	preferNoSchedule(t.client, t.nodeID, t.taintName, t.effect, false)
 }
 


### PR DESCRIPTION
This implements https://github.com/weaveworks/kured/issues/19

The idea is to set a prefer no schedule taint.
The taint is set when the reboot sentinel is found and removed after the restart.

In case the node can not restart immediately the taint asks the kubernetes scheduler to avoid placing new pods on the tainted node.
But this is only preferred, as a last resort the kubernetes scheduler does place pods onto the node.