### PR TITLE
Do not bump kubernetes with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "k8s.io/kubectl"
+      - dependency-name: "k8s.io/apimachinery"


### PR DESCRIPTION
Without this patch, we'll get kubernetes updates.

This is not necessary, and could be even a problem on merge:
those kubernetes updates are done separately, knowingly,
to respect the life cycle of the kubernetes we need
(and stay one version below latest to have a larger coverage
of versions).

We could keep dependabot to update those on a lower frequency,
but that sounds clunky and not great. Instead disable them all,
and rely on the team to do this regular maintenance work.
