### PR TITLE
Force golang version

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -17,6 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Find go version
+      run: |
+        GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+        echo "::set-output name=version::${GO_VERSION}"
+      id: awk_gomod
+    - name: Ensure go version:
+      uses: actions/setup-go@v2
+      with:
+        go-version: "${{ steps.awk_gomod.outputs.version }}"
     - name: Lint cmd folder
       uses: Jerome1337/golint-action@v1.0.2
       with:
@@ -47,6 +56,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+      - name: Ensure go version:
+        uses: actions/setup-go@v2
+        with:
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
       - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
       - uses: Azure/container-scan@v0
         with:
@@ -64,8 +82,15 @@ jobs:
           - 1.19
     steps:
       - uses: actions/checkout@v2
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+      - name: Ensure go version:
+        uses: actions/setup-go@v2
         with:
-          fetch-depth: "0"
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
       - name: Build artifacts
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
@@ -131,8 +156,15 @@ jobs:
           - 1.18
     steps:
       - uses: actions/checkout@v2
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+      - name: Ensure go version:
+        uses: actions/setup-go@v2
         with:
-          fetch-depth: "0"
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
       - name: Build artifacts
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -9,9 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
-
       - name: Publish Helm chart
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -7,13 +7,21 @@ on:
   push:
     tags:
       - "*"
-
 jobs:
   tag-scan-and-push-final-image:
     name: "Build, scan, and publish tagged image"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+      - name: Ensure go version
+        uses: actions/setup-go@v2
+        with:
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
       - run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${GITHUB_REF#refs/tags/}" image
       - uses: Azure/container-scan@v0

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -38,6 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+      - name: Ensure go version
+        uses: actions/setup-go@v2
+        with:
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
       - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
       - uses: Azure/container-scan@v0
         with:
@@ -55,8 +64,15 @@ jobs:
           - 1.19
     steps:
       - uses: actions/checkout@v2
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+      - name: Ensure go version
+        uses: actions/setup-go@v2
         with:
-          fetch-depth: "0"
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
       - name: Build artifacts
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="master" image


### PR DESCRIPTION
Without this, golang version used is the golang version decided
by github.

This is a problem, as it might shift over time, without our control.

This fixes it by getting the golang version from the go.mod.
