### PR TITLE
Fix typo in github workflows

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -22,7 +22,7 @@ jobs:
         GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
         echo "::set-output name=version::${GO_VERSION}"
       id: awk_gomod
-    - name: Ensure go version:
+    - name: Ensure go version
       uses: actions/setup-go@v2
       with:
         go-version: "${{ steps.awk_gomod.outputs.version }}"
@@ -61,7 +61,7 @@ jobs:
           GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
           echo "::set-output name=version::${GO_VERSION}"
         id: awk_gomod
-      - name: Ensure go version:
+      - name: Ensure go version
         uses: actions/setup-go@v2
         with:
           go-version: "${{ steps.awk_gomod.outputs.version }}"
@@ -87,7 +87,7 @@ jobs:
           GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
           echo "::set-output name=version::${GO_VERSION}"
         id: awk_gomod
-      - name: Ensure go version:
+      - name: Ensure go version
         uses: actions/setup-go@v2
         with:
           go-version: "${{ steps.awk_gomod.outputs.version }}"
@@ -161,7 +161,7 @@ jobs:
           GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
           echo "::set-output name=version::${GO_VERSION}"
         id: awk_gomod
-      - name: Ensure go version:
+      - name: Ensure go version
         uses: actions/setup-go@v2
         with:
           go-version: "${{ steps.awk_gomod.outputs.version }}"


### PR DESCRIPTION
Without this patch, the PR jobs are broken and no jobs are running.
This was a recently introduced typo in the last refactor of the
PR jobs.

This should fix it, and make the PR test working again.
