### PR TITLE
Publish image on master merged changes

### DIFF
--- a/.github/workflows/on-master-push.yaml
+++ b/.github/workflows/on-master-push.yaml
@@ -1,0 +1,38 @@
+# We publish every merged commit in the form of an image
+# named kured:<branch>-<short tag>
+name: Push image of latest master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  tag-scan-and-push-final-image:
+    name: "Build, scan, and publish tagged image"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Find go version
+        run: |
+          GO_VERSION=$(awk '/^go/ {print $2};' go.mod)
+          echo "::set-output name=version::${GO_VERSION}"
+        id: awk_gomod
+
+      - name: Ensure go version
+        uses: actions/setup-go@v2
+        with:
+          go-version: "${{ steps.awk_gomod.outputs.version }}"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME_WEAVEWORKSKUREDCI }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_WEAVEWORKSKUREDCI }}
+
+      - name: Build image
+        run: |
+          make DH_ORG="${{ github.repository_owner }}" image
+
+      - name: Publish image
+        run: |
+          make DH_ORG="${{ github.repository_owner }}" publish-image


### PR DESCRIPTION
As we are pretty much committed to github actions, we should
probably rely on it to push the images at each commit merged
on the master branch.
