### PR TITLE
Fix comment spacing

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.1"
 description: A Helm chart for kured
 name: kured
-version: 2.2.2
+version: 2.2.3
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -20,22 +20,22 @@ extraEnvVars:
 #    value: 123
 
 configuration:
-  lockTtl: 0                # force clean annotation after this ammount of time (default 0, disabled)
-  alertFilterRegexp: ""     # alert names to ignore when checking for active alerts
-  blockingPodSelector: []   # label selector identifying pods whose presence should prevent reboots
-  endTime: ""               # only reboot before this time of day (default "23:59")
-  lockAnnotation: ""        # annotation in which to record locking node (default "weave.works/kured-node-lock")
-  period: ""                # reboot check period (default 1h0m0s)
-  prometheusUrl: ""         # Prometheus instance to probe for active alerts
-  rebootDays: []            # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
-  rebootSentinel: ""        # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-  slackChannel: ""          # slack channel for reboot notfications
-  slackHookUrl: ""          # slack hook URL for reboot notfications
-  slackUsername: ""         # slack username for reboot notfications (default "kured")
-  messageTemplateDrain: ""  # slack message template when notifying about a node being drained (default "Draining node %s")
-  messageTemplateReboot: "" # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
-  startTime: ""             # only reboot after this time of day (default "0:00")
-  timeZone: ""              # time-zone to use (valid zones from "time" golang package)
+  lockTtl: 0                 # force clean annotation after this ammount of time (default 0, disabled)
+  alertFilterRegexp: ""      # alert names to ignore when checking for active alerts
+  blockingPodSelector: []    # label selector identifying pods whose presence should prevent reboots
+  endTime: ""                # only reboot before this time of day (default "23:59")
+  lockAnnotation: ""         # annotation in which to record locking node (default "weave.works/kured-node-lock")
+  period: ""                 # reboot check period (default 1h0m0s)
+  prometheusUrl: ""          # Prometheus instance to probe for active alerts
+  rebootDays: []             # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+  rebootSentinel: ""         # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
+  slackChannel: ""           # slack channel for reboot notfications
+  slackHookUrl: ""           # slack hook URL for reboot notfications
+  slackUsername: ""          # slack username for reboot notfications (default "kured")
+  messageTemplateDrain: ""   # slack message template when notifying about a node being drained (default "Draining node %s")
+  messageTemplateReboot: ""  # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
+  startTime: ""              # only reboot after this time of day (default "0:00")
+  timeZone: ""               # time-zone to use (valid zones from "time" golang package)
 
 rbac:
   create: true


### PR DESCRIPTION
Without this patch, chart linting will fail: more than two
spaces are needed before a comment in the helm chart values.

This fixes it by adding one more space, and move the whole block
of comments for consistency.
