### PR TITLE
Do not bump any k8s module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "k8s.io/kubectl"
+      - dependency-name: "k8s.io/api"
       - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/kubectl"


### PR DESCRIPTION
Without this patch, dependabot will still try to bump some k8s
dependencies.

This is a problem, as we need to bump them together, manually.

This should fix it by removing them all from dependabot.
