### PR TITLE
Temporarily workaround alpine issue

### DIFF
--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.12
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk update --no-cache && apk upgrade --no-cache && apk add --no-cache ca-certificates tzdata
 COPY ./kured /usr/bin/kured
 ENTRYPOINT ["/usr/bin/kured"]


### PR DESCRIPTION
Until a new alpine image is created, we should ensure the latest
packages are used, and therefore we should upgrade default
installed packages.

Without this patch, we'll have outdated and vulnerable packages
until a new 3.12 image is released.

This is a problem, as we'll publish broken images.

This should temporarily workaround it, at the expense of larger
images (contains package cache)
