### PR TITLE
Add force-reboot after force-timeout duration has been exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ The following arguments can be passed to kured via the daemonset pod template:
 Flags:
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
+      --drain-grace-period int              period of time to wait for node drain in seconds (default -1)
       --ds-name string                      name of daemonset on which to place lock (default "kured")
       --ds-namespace string                 namespace containing daemonset on which to place lock (default "kube-system")
       --end-time string                     schedule reboot only before this time of day (default "23:59:59")
+      --force-reboot bool                   force a reboot even if the drain is still running (default false)
+      --force-timeout duration              total drain timeout, only applies when force-reboot is enabled (default 30m)
   -h, --help                                help for kured
       --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
       --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)

--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.1"
 description: A Helm chart for kured
 name: kured
-version: 2.3.1
+version: 2.3.2
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -50,6 +50,7 @@ The following changes have been made compared to the stable chart:
 | `configuration.endTime` | cli-parameter `--end-time`                                                  | `""`                      |
 | `configuration.lockAnnotation` | cli-parameter `--lock-annotation`                                    | `""`                      |
 | `configuration.period` | cli-parameter `--period`                                                     | `""`                      |
+| `configuration.drainGracePeriod` | cli-parameter `--drain-grace-period`                               | `""`                      |
 | `configuration.prometheusUrl` | cli-parameter `--prometheus-url`                                      | `""`                      |
 | `configuration.rebootDays` | Array of days for multiple cli-parameters `--reboot-days`                | `[]`                      |
 | `configuration.rebootSentinel` | cli-parameter `--reboot-sentinel`                                    | `""`                      |
@@ -60,6 +61,8 @@ The following changes have been made compared to the stable chart:
 | `configuration.messageTemplateReboot` | cli-parameter `--message-template-reboot`                     | `""`                      |
 | `configuration.startTime` | cli-parameter `--start-time`                                              | `""`                      |
 | `configuration.timeZone` | cli-parameter `--time-zone`                                                | `""`                      |
+| `configuration.forceReboot` | cli-parameter `--force-reboot`                                          | `false`                   |
+| `configuration.forceTimeout` | cli-parameter `--force-timeout`                                        | `""`                      |
 | `rbac.create`           | Create RBAC roles                                                           | `true`                     |
 | `serviceAccount.create` | Create a service account                                                    | `true`                     |
 | `serviceAccount.name`   | Service account name to create (or use if `serviceAccount.create` is false) | (chart fullname)           |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -67,6 +67,9 @@ spec:
           {{- if .Values.configuration.period }}
             - --period={{ .Values.configuration.period }}
           {{- end }}
+          {{- if .Values.configuration.drainGracePeriod }}
+            - --drain-grace-period={{ .Values.configuration.drainGracePeriod }}
+          {{- end }}
           {{- if .Values.configuration.prometheusUrl }}
             - --prometheus-url={{ .Values.configuration.prometheusUrl }}
           {{- end }}
@@ -96,6 +99,12 @@ spec:
           {{- end }}
           {{- if .Values.configuration.timeZone }}
             - --time-zone={{ .Values.configuration.timeZone }}
+          {{- end }}
+          {{- if .Values.configuration.forceReboot }}
+            - --force-reboot
+          {{- end }}
+          {{- if .Values.configuration.forceTimeout }}
+            - --force-timeout={{ .Values.configuration.forceTimeout }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}

--- a/charts/kured/values.minikube.yaml
+++ b/charts/kured/values.minikube.yaml
@@ -9,6 +9,7 @@ configuration:
   # endTime: ""               # only reboot before this time of day (default "23:59")
   # lockAnnotation: ""        # annotation in which to record locking node (default "weave.works/kured-node-lock")
   period: "1m"                # reboot check period (default 1h0m0s)
+  # drainGracePeriod: ""      # period of time to wait for node drain in seconds (default -1)
   # prometheusUrl: ""         # Prometheus instance to probe for active alerts
   # rebootDays: []            # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
   # rebootSentinel: ""        # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
@@ -19,3 +20,5 @@ configuration:
   # messageTemplateReboot: "" # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
   # startTime: ""             # only reboot after this time of day (default "0:00")
   # timeZone: ""              # time-zone to use (valid zones from "time" golang package)
+  # forceReboot: false        # force a reboot even if the drain is still running (default false)
+  # forceTimeout: ""          # total drain timeout, only applies when force-reboot is enabled (default 30m)

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -28,6 +28,7 @@ configuration:
   endTime: ""                # only reboot before this time of day (default "23:59")
   lockAnnotation: ""         # annotation in which to record locking node (default "weave.works/kured-node-lock")
   period: ""                 # reboot check period (default 1h0m0s)
+  drainGracePeriod: ""       # period of time to wait for node drain in seconds (default -1)
   prometheusUrl: ""          # Prometheus instance to probe for active alerts
   rebootDays: []             # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
   rebootSentinel: ""         # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
@@ -38,6 +39,8 @@ configuration:
   messageTemplateReboot: ""  # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
   startTime: ""              # only reboot after this time of day (default "0:00")
   timeZone: ""               # time-zone to use (valid zones from "time" golang package)
+  forceReboot: false         # force a reboot even if the drain is still running (default false)
+  forceTimeout: ""           # total drain timeout, only applies when force-reboot is enabled (default 30m)
 
 rbac:
   create: true


### PR DESCRIPTION
Updated version of https://github.com/weaveworks/kured/pull/109 which passes in the force-timeout parameter into the kubectl drain helper configuration, utilizing Go context cancellation instead.

I also updated the helm chart to support passing the new parameters.