### PR TITLE
Expose the service name and maxUnavailable for rolling updates in helm chart

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.1"
 description: A Helm chart for kured
 name: kured
-version: 2.2.3
+version: 2.2.4
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -40,6 +40,7 @@ The following changes have been made compared to the stable chart:
 | `image.pullPolicy`      | Image pull policy                                                           | `IfNotPresent`             |
 | `image.pullSecrets`     | Image pull secrets                                                          | `[]`                       |
 | `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |
+| `maxUnavailable`        | The max pods unavailable during a rolling update                            | `1`                        |
 | `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
 | `extraEnvVars`          | Array of environment variables to pass to the daemonset.                    | `{}`                       |
@@ -70,6 +71,7 @@ The following changes have been made compared to the stable chart:
 | `metrics.interval`      | Interval prometheus should scrape the endpoint                              | `60s`                   |
 | `metrics.scrapeTimeout` | A custom scrapeTimeout for prometheus                                       | `""`                    |
 | `service.create`        | Create a Service for the metrics endpoint                                   | `false`                    |
+| `service.name  `        | Service name for the metrics endpoint                                       | `""`                       |
 | `service.port`          | Port of the service to expose                                               | `8080`                     |
 | `service.annotations`   | Annotations to apply to the service (eg to add Prometheus annotations)      | `{}`                       |
 | `priorityClassName`     | Priority Class to be used by the pods                                       | `""`                       |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   updateStrategy:
     type: {{ .Values.updateStrategy }}
+{{- if eq .Values.updateStrategy "RollingUpdate"}}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable }}
+{{- end}}
   selector:
     matchLabels:
       {{- include "kured.matchLabels" . | nindent 6 }}

--- a/charts/kured/templates/service.yaml
+++ b/charts/kured/templates/service.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+  {{- else }}
   name: {{ template "kured.fullname" . }}
+  {{- end }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -5,6 +5,8 @@ image:
   pullSecrets: []
 
 updateStrategy: OnDelete
+#  requires RollingUpdate updateStrategy
+maxUnavailable: 1
 
 podAnnotations: {}
 
@@ -60,6 +62,7 @@ service:
   create: false
   port: 8080
   annotations: {}
+  name: ""
 
 priorityClassName: ""
 


### PR DESCRIPTION
A small helm update to expose setting the service name for the service, and expose maxUnavailable when the the `updateStrategy` is set to `RollingUpdate`.