### PR TITLE
Update helm chart README using Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,5 @@ helm-chart:
 	sed -i "s#repository:.*/kured#repository: $(DH_ORG)/kured#g" charts/kured/values.yaml
 	sed -i "s#tag:.*#tag: $(VERSION)#g" charts/kured/values.yaml
 	sed -i "s#appVersion:.*#appVersion: \"$(VERSION)\"#g" charts/kured/Chart.yaml
+	sed -i "s#\`[0-9]*\.[0-9]*\.[0-9]*\`#\`$(VERSION)\`#g" charts/kured/README.md
 	echo "Please bump version in charts/kured/Chart.yaml"

--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.1"
 description: A Helm chart for kured
 name: kured
-version: 2.3.0
+version: 2.3.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -36,7 +36,7 @@ The following changes have been made compared to the stable chart:
 | Config                  | Description                                                                 | Default                    |
 | ------                  | -----------                                                                 | -------                    |
 | `image.repository`      | Image repository                                                            | `weaveworks/kured` |
-| `image.tag`             | Image tag                                                                   | `1.5.1`                    |
+| `image.tag`             | Image tag                                                                   | `1.6.1`                    |
 | `image.pullPolicy`      | Image pull policy                                                           | `IfNotPresent`             |
 | `image.pullSecrets`     | Image pull secrets                                                          | `[]`                       |
 | `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |


### PR DESCRIPTION
Without this, it's possible that the helm chart documentation
contains the `image tag` version which might not be equal to
the version in the helm chart, as it's only an example.

This is a confusing, so instead we should use make to edit the
application version everywhere.

This fixes it by updating the Makefile to modify text of the
chart's README using a regex looking for something similar to
a version; then I used the updated makefile to edit the README.
