### PR TITLE
always drain before reboot

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -377,9 +377,7 @@ func rebootAsRequired(nodeID string, window *timewindow.TimeWindow, TTL time.Dur
 			continue
 		}
 
-		if !nodeMeta.Unschedulable {
-			drain(client, node)
-		}
+		drain(client, node)
 		commandReboot(nodeID)
 		for {
 			log.Infof("Waiting for reboot")


### PR DESCRIPTION
This PR changes the pre-reboot drain functionality so that it *always* runs, regardless of the value of the `Unschedulable` node property. Ostensibly this "skip if unschedulable" foo was added due to the fact that the value of `Unschedulable` will be set to false as a side-effect of a kured reboot operation, and if we're in a "retry" loop here, we shouldn't have to "drain again".

However, because kubectl drain is idempotent, we shouldn't have to worry about any of that: we can run it over and over again. And because this `drain` func actually does a cordon + drain (and it only performs the drain *if* a cordon is successful), we can be sure that we aren't going to be thrashing this node w/ respect to scheduled pods.

And in fact, the current implementation of "only drain if node is marked Unschedulable" presents an edge case: if the node has been marked Unschedulable out-of-band, but workloads remain Running on this node, we will reboot the node's underlying VM/machine while it is actively running pods.

Fixes #18 

PS 👋 thanks for kured! :)