### PR TITLE
add node annotations to identify kured reboot operations

### DIFF
--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -63,3 +63,4 @@ spec:
 #            - --message-template-drain=Rebooting node %s
 #            - --start-time=0:00
 #            - --time-zone=UTC
+#            - --annotate-nodes=false


### PR DESCRIPTION
This PR adds a new `--annotate-nodes` daemonset runtime argument, which does the following when enabled:

- adds a new node annotation `"weave.works/kured-most-recent-reboot-needed"` with a value of the current RFC3339 timestamp *as soon as kured identifies that a node needs to be rebooted*
- adds a new node annotation `"weave.works/kured-reboot-in-progress"` with a value of the current RFC3339 timestamp *as soon as kured identifies that a node needs to be rebooted*

The purpose of these node annotations is to allow other k8s node maintenance tooling to know about what kured is doing to these nodes. As a concrete example, this alpha project aims to take an OS disk image snapshot of a stable node in a cluster in order to update our "node pool recipe" to use it for future node scale out operations:

https://github.com/jackfrancis/kamino

We want to be able to run kured on a cluster that uses the kamino tooling to regularly reboot and apply OS patches delivered via `unattended-upgrades`; and we want to know what kured is doing to keep our clusters up-to-date. Specifically, we want to know the following:

- Is this node going to be rebooted (or is in the act of rebooting) via kured? If so, we will conclude that this node is not (yet) in a stable state, and so we want to pass it over when considering which node to take a definitive OS disk image snapshot of.
- When was this node last marked for reboot? From this timestamp we can evaluate which node in our cluster was most recently updated, which may be used to determine candidacy for being "the node we *do* want to take an OS disk image snapshot of".

The `"weave.works/kured-reboot-in-progress"` is in-practice a boolean annotation, but it is implemented as a key/val with the value being the timestamp, so that it carries additional semantic value in the event that something prevents the reboot from succeeding (it will tell us how long the reboot has been trying but failing to reboot). The annotation is deleted once kured has determined that the reboot has succeeded, in the same flow that the "release lock" work happens. In practice this means that consuming tools can query for the existence of the `"weave.works/kured-reboot-in-progress"` annotation on a node to definitively determine if that node is essentially held for exclusive operational maintenance by kured.

This PR aims to put 100% of the above-described, net-new functionality behind a "feature flag"-like interface (i.e., the `--annotate-nodes`). For folks who don't know about this new feature, or don't want to use it, they should not be affected at all.