### PR TITLE
Implement universal notification mechanism (NEW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,20 +219,30 @@ If you choose to employ such an alert and have configured kured to
 probe for active alerts before rebooting, be sure to specify
 `--alert-filter-regexp=^RebootRequired$` to avoid deadlock!
 
-### Slack Notifications
+### Notifications
 
-If you specify a Slack hook via `--slack-hook-url`, kured will notify
-you immediately prior to rebooting a node:
-
+When you specify a formatted URL using `--notify-url`, kured will notify
+about draining and rebooting nodes across a list of technologies. 
 ![Notification](img/slack-notification.png)
-
-We recommend setting `--slack-username` to be the name of the
-environment, e.g. `dev` or `prod`.
 
 Alternatively you can use the `--message-template-drain` and `--message-template-reboot` to customize the text of the message, e.g.
 ```
 --message-template-drain="Draining node %s part of *my-cluster* in region *xyz*"
 ```
+
+Here is the syntax:
+
+slack:           `slack://tokenA/tokenB/tokenC`
+(`--slack-hook-url` is deprecated but possible to use)
+
+rocketchat:      `rocketchat://[username@]rocketchat-host/token[/channel|@recipient]`
+
+teams:           `teams://token-a/token-b/token-c`
+
+Email:           `smtp://username:password@host:port/?fromAddress=fromAddress&toAddresses=recipient1[,recipient2,...]`
+
+More details here: https://github.com/containrrr/shoutrrr/blob/master/docs/services/overview.md
+
 
 ### Overriding Lock Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/weaveworks/kured
 go 1.15
 
 require (
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/containrrr/shoutrrr v0.4.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/common v0.15.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,7 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containrrr/shoutrrr v0.4.1/go.mod h1:zqL2BvfC1W4FujrT4b3/ZCLxvD+uoeEpBL7rg9Dqpbg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=


### PR DESCRIPTION
 Without this patch, kured can only notify via slack.

 This patch gives the possibility to send notifications
 across different technologies. Also, this patch makes
 slack-hook-url, slack-username and slack-channel
 deprecated (informed by a warning).
 Also, updated the documentation (Readme).