### PR TITLE
Add chart-testing target-branch

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,5 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
+target-branch: main
 chart-dirs:
   - charts
 chart-repos: []


### PR DESCRIPTION
Without this patch, chart-testing is using the branch named
"master" by default.

This is a problem, as we just renamed our development branch
"main" instead of "master".

This should fix it by pointing to the right branch.
