### PR TITLE
Add parameter for delaying release of lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,11 @@ which holds lock might be killed thus annotation will stay there for ever.
 
 Using `--lock-ttl=30m` will allow other nodes to take over if TTL has expired (in this case 30min) and continue reboot process.
 
+### Delaying Lock Release
+
+
+Using `--lock-release-delay=30m` will cause nodes to hold the lock for the specified time frame (in this case 30min) before it is released and the reboot process continues. This can be used to throttle reboots across the cluster.
+
 ## Building
 
 Kured now uses [Go

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -64,3 +64,4 @@ spec:
 #            - --start-time=0:00
 #            - --time-zone=UTC
 #            - --annotate-nodes=false
+#            - --lock-release-delay=30m


### PR DESCRIPTION
This change supports throttling of reboots across the cluster by adding a new command line flag --lock-release-delay. When specified nodes will hold the lock for the provided amount of time after rebooting. That way pods can reschedule on the rebooted node and state can be replicated before the next node is rebooted.

Issue : #277