### PR TITLE
Add lockReleaseDelay parameter to helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Flags:
   -h, --help                                help for kured
       --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
       --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
+      --lock-release-delay duration         hold lock after reboot by this duration (default: 0, disabled)
       --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
       --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
       --notify-url                          url for reboot notifications (cannot use with --slack-hook-url flags)

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Flags:
       --drain-timeout duration              timeout after which the drain is aborted (default: 0, infinite time)
   -h, --help                                help for kured
       --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
-      --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
       --lock-release-delay duration         hold lock after reboot by this duration (default: 0, disabled)
+      --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
       --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
       --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
       --notify-url                          url for reboot notifications (cannot use with --slack-hook-url flags)

--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.7.0"
 description: A Helm chart for kured
 name: kured
-version: 2.5.0
+version: 2.6.0
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -45,6 +45,7 @@ The following changes have been made compared to the stable chart:
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
 | `extraEnvVars`          | Array of environment variables to pass to the daemonset.                    | `{}`                       |
 | `configuration.lockTtl` | cli-parameter `--lock-ttl`                                                  | `0`                       |
+| `configuration.lockReleaseDelay` | cli-parameter `--lock-release-delay`                               | `0`                       |
 | `configuration.alertFilterRegexp` | cli-parameter `--alert-filter-regexp`                             | `""`                       |
 | `configuration.blockingPodSelector` | Array of selectors for multiple cli-parameters `--blocking-pod-selector` | `[]`             |
 | `configuration.endTime` | cli-parameter `--end-time`                                                  | `""`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if .Values.configuration.lockTtl }}
             - --lock-ttl={{ .Values.configuration.lockTtl }}
           {{- end }}
+          {{- if .Values.configuration.lockReleaseDelay }}
+            - --lock-release-delay={{ .Values.configuration.lockReleaseDelay }}
+          {{- end }}
           {{- if .Values.configuration.alertFilterRegexp }}
             - --alert-filter-regexp={{ .Values.configuration.alertFilterRegexp }}
           {{- end }}

--- a/charts/kured/values.minikube.yaml
+++ b/charts/kured/values.minikube.yaml
@@ -21,3 +21,4 @@ configuration:
   # startTime: ""             # only reboot after this time of day (default "0:00")
   # timeZone: ""              # time-zone to use (valid zones from "time" golang package)
   # annotateNodes: false       # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
+  # lockReleaseDelay: "5m"    # throttle node reboots

--- a/charts/kured/values.minikube.yaml
+++ b/charts/kured/values.minikube.yaml
@@ -20,5 +20,5 @@ configuration:
   # messageTemplateReboot: "" # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
   # startTime: ""             # only reboot after this time of day (default "0:00")
   # timeZone: ""              # time-zone to use (valid zones from "time" golang package)
-  # annotateNodes: false       # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
-  # lockReleaseDelay: "5m"    # throttle node reboots
+  # annotateNodes: false      # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
+  # lockReleaseDelay: "5m"    # hold lock after reboot by this amount of time (default 0, disabled)

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -39,7 +39,8 @@ configuration:
   messageTemplateReboot: ""  # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
   startTime: ""              # only reboot after this time of day (default "0:00")
   timeZone: ""               # time-zone to use (valid zones from "time" golang package)
-  annotateNodes: false        # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
+  annotateNodes: false       # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
+  lockReleaseDelay: 0        # hold lock after reboot by this amount of time (default 0, disabled)
 
 rbac:
   create: true


### PR DESCRIPTION
Adds support for the --lock-release-delay parameter that was added in #352 to the helm chart. Setting `configuration.lockReleaseDelay=1h` for instance throttles node reboots to at most 1 per hour.

Issue: #277