### PR TITLE
Add force-reboot and drain timeouts to chart config and ds

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.7.0"
 description: A Helm chart for kured
 name: kured
-version: 2.9.0
+version: 2.9.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -51,6 +51,10 @@ The following changes have been made compared to the stable chart:
 | `configuration.endTime` | cli-parameter `--end-time`                                                  | `""`                      |
 | `configuration.lockAnnotation` | cli-parameter `--lock-annotation`                                    | `""`                      |
 | `configuration.period` | cli-parameter `--period`                                                     | `""`                      |
+| `configuration.forceReboot` | cli-parameter `--force-reboot`                                          | `false`                   |
+| `configuration.drainGracePeriod` | cli-parameter `--drain-grace-period`                               | `""`                      |
+| `configuration.drainTimeout` | cli-parameter `--drain-timeout`                                        | `""`                      |
+| `configuration.skipWaitForDeleteTimeout` | cli-parameter `--skip-wait-for-delete-timeout`             | `""`                      |
 | `configuration.prometheusUrl` | cli-parameter `--prometheus-url`                                      | `""`                      |
 | `configuration.rebootDays` | Array of days for multiple cli-parameters `--reboot-days`                | `[]`                      |
 | `configuration.rebootSentinel` | cli-parameter `--reboot-sentinel`                                    | `""`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -73,6 +73,18 @@ spec:
           {{- if .Values.configuration.period }}
             - --period={{ .Values.configuration.period }}
           {{- end }}
+          {{- if .Values.configuration.forceReboot }}
+           - --force-reboot
+          {{- end }}
+          {{- if .Values.configuration.drainGracePeriod }}
+            - --drain-grace-period={{ .Values.configuration.drainGracePeriod }}
+          {{- end }}
+          {{- if .Values.configuration.drainTimeout }}
+            - --drain-timeout={{ .Values.configuration.drainTimeout }}
+          {{- end }}
+          {{- if .Values.configuration.skipWaitForDeleteTimeout }}
+             - --skip-wait-for-delete-timeout={{ .Values.configuration.skipWaitForDeleteTimeout }}
+          {{- end }}
           {{- if .Values.configuration.prometheusUrl }}
             - --prometheus-url={{ .Values.configuration.prometheusUrl }}
           {{- end }}

--- a/charts/kured/values.minikube.yaml
+++ b/charts/kured/values.minikube.yaml
@@ -3,12 +3,16 @@ image:
   tag: latest
 
 configuration:
-  # annotationTtl: 0          # force clean annotation after this ammount of time (default 0, disabled)
+  # annotationTtl: 0          # force clean annotation after this amount of time (default 0, disabled)
   # alertFilterRegexp: ""     # alert names to ignore when checking for active alerts
   # blockingPodSelector: []   # label selector identifying pods whose presence should prevent reboots
   # endTime: ""               # only reboot before this time of day (default "23:59")
   # lockAnnotation: ""        # annotation in which to record locking node (default "weave.works/kured-node-lock")
   period: "1m"                # reboot check period (default 1h0m0s)
+  # forceReboot: false        # force a reboot even if the drain fails or times out (default: false)
+  # drainGracePeriod: ""      # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+  # drainTimeout: ""          # timeout after which the drain is aborted (default: 0, infinite time)
+  # skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
   # prometheusUrl: ""         # Prometheus instance to probe for active alerts
   # rebootDays: []            # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
   # rebootSentinel: ""        # path to file whose existence signals need to reboot (default "/var/run/reboot-required")

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -22,12 +22,16 @@ extraEnvVars:
 #    value: 123
 
 configuration:
-  lockTtl: 0                 # force clean annotation after this ammount of time (default 0, disabled)
+  lockTtl: 0                 # force clean annotation after this amount of time (default 0, disabled)
   alertFilterRegexp: ""      # alert names to ignore when checking for active alerts
   blockingPodSelector: []    # label selector identifying pods whose presence should prevent reboots
   endTime: ""                # only reboot before this time of day (default "23:59")
   lockAnnotation: ""         # annotation in which to record locking node (default "weave.works/kured-node-lock")
   period: ""                 # reboot check period (default 1h0m0s)
+  forceReboot: false         # force a reboot even if the drain fails or times out (default: false)
+  drainGracePeriod: ""       # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+  drainTimeout: ""           # timeout after which the drain is aborted (default: 0, infinite time)
+  skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
   prometheusUrl: ""          # Prometheus instance to probe for active alerts
   rebootDays: []             # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
   rebootSentinel: ""         # path to file whose existence signals need to reboot (default "/var/run/reboot-required")

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -100,7 +100,7 @@ func main() {
 		Run:    root}
 
 	rootCmd.PersistentFlags().BoolVar(&forceReboot, "force-reboot", false,
-		"force a reboot even if the drain is still running (default: false)")
+		"force a reboot even if the drain fails or times out (default: false)")
 	rootCmd.PersistentFlags().IntVar(&drainGracePeriod, "drain-grace-period", -1,
 		"time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)")
 	rootCmd.PersistentFlags().IntVar(&skipWaitForDeleteTimeoutSeconds, "skip-wait-for-delete-timeout", 0,


### PR DESCRIPTION
Followup from https://github.com/weaveworks/kured/pull/341, exposes all of the new cli flags to the helm chart.