### PR TITLE
Use stable kind-action

### DIFF
--- a/.github/workflows/on-pr-charts.yaml
+++ b/.github/workflows/on-pr-charts.yaml
@@ -50,7 +50,7 @@ jobs:
       
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 1 node kind cluster
-        uses: helm/kind-action@master
+        uses: helm/kind-action@v1.1.0
 
       - name: Deploy kured on default namespace with its helm chart
         run: |

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -122,7 +122,7 @@ jobs:
 
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 5 node kind cluster
-        uses: helm/kind-action@master
+        uses: helm/kind-action@v1.1.0
         with:
           config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
 
@@ -195,7 +195,7 @@ jobs:
           EOF
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create kind cluster
-        uses: helm/kind-action@master
+        uses: helm/kind-action@v1.1.0
         with:
           config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
       - name: Preload previously built images onto kind cluster
@@ -248,7 +248,7 @@ jobs:
 
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 1 node kind cluster
-        uses: helm/kind-action@master
+        uses: helm/kind-action@v1.1.0
 
       - name: Preload previously built images onto kind cluster
         run: kind load docker-image docker.io/${{ github.repository_owner }}/kured:${{ github.sha }} --name chart-testing

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -104,7 +104,7 @@ jobs:
 
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 5 node kind cluster
-        uses: helm/kind-action@master
+        uses: helm/kind-action@v1.1.0
         with:
           config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
 


### PR DESCRIPTION
We are relying on master, which might break anytime (or in this
case, moved to another branch).

Instead we should rely on a stable version, and unfreeze if
necessary. Dependabot helps us maintain those releases anyway.
