### PR TITLE
link to versioned shoutrrr docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Here is the syntax:
 
 - Email:           `smtp://username:password@host:port/?fromAddress=fromAddress&toAddresses=recipient1[,recipient2,...]`
 
-More details here: <https://github.com/containrrr/shoutrrr/blob/main/docs/services/overview.md>
+More details here: [containrrr.dev/shoutrrr/v0.4/services/overview](https://containrrr.dev/shoutrrr/v0.4/services/overview)
 
 ### Overriding Lock Configuration
 


### PR DESCRIPTION
shoutrrr now have versioned docs to allow directly linking to the version that matches the one you use
changes should always backwards compatible, but not the other way around