### PR TITLE
fix: common default reboot command for code and chart

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.7.0"
 description: A Helm chart for kured
 name: kured
-version: 2.7.0
+version: 2.7.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -31,7 +31,7 @@ configuration:
   prometheusUrl: ""          # Prometheus instance to probe for active alerts
   rebootDays: []             # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
   rebootSentinel: ""         # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-  rebootCommand: "/sbin/systemctl reboot"  # command to run when a reboot is required by the sentinel
+  rebootCommand: "/bin/systemctl reboot"  # command to run when a reboot is required by the sentinel
   slackChannel: ""           # slack channel for reboot notfications
   slackHookUrl: ""           # slack hook URL for reboot notfications
   slackUsername: ""          # slack username for reboot notfications (default "kured")


### PR DESCRIPTION
This PR changes the default chart `rebootCommand` value to match the default in-code `--reboot-command` arg: "/bin/systemctl reboot".

Without this fix, Kured 1.7.0 is regressive for environments that don't have `/sbin/systemctl` present on their Linux distribution.

Original change was here:

https://github.com/weaveworks/kured/pull/394

Fixes #404 