### PR TITLE
Add `label-with-exclude-from-external-lbs` CLI argument to enable graceful removal/addition from external load balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,37 +85,38 @@ The following arguments can be passed to kured via the daemonset pod template:
 
 ```console
 Flags:
-      --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
-      --alert-firing-only bool              only consider firing alerts when checking for active alerts
-      --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
-      --drain-grace-period int              time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
-      --skip-wait-for-delete-timeout int    when seconds is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
-      --ds-name string                      name of daemonset on which to place lock (default "kured")
-      --ds-namespace string                 namespace containing daemonset on which to place lock (default "kube-system")
-      --end-time string                     schedule reboot only before this time of day (default "23:59:59")
-      --force-reboot bool                   force a reboot even if the drain is still running (default: false)
-      --drain-timeout duration              timeout after which the drain is aborted (default: 0, infinite time)
-  -h, --help                                help for kured
-      --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
-      --lock-release-delay duration         hold lock after reboot by this duration (default: 0, disabled)
-      --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
-      --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
-      --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
-      --notify-url                          url for reboot notifications (cannot use with --slack-hook-url flags)
-      --period duration                     reboot check period (default 1h0m0s)
-      --prefer-no-schedule-taint string     Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to "weave.works/kured-node-reboot" to enable tainting.
-      --prometheus-url string               Prometheus instance to probe for active alerts
-      --reboot-command string               command to run when a reboot is required by the sentinel (default "/sbin/systemctl reboot")
-      --reboot-days strings                 schedule reboot on these days (default [su,mo,tu,we,th,fr,sa])
-      --reboot-delay duration               add a delay after drain finishes but before the reboot command is issued (default 0, no time)
-      --reboot-sentinel string              path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-      --reboot-sentinel-command string      command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
-      --slack-channel string                slack channel for reboot notfications
-      --slack-hook-url string               slack hook URL for reboot notfications [deprecated in favor of --notify-url]
-      --slack-username string               slack username for reboot notfications (default "kured")
-      --start-time string                   schedule reboot only after this time of day (default "0:00")
-      --time-zone string                    use this timezone for schedule inputs (default "UTC")
-      --log-format string                   log format specified as text or json, defaults to "text"
+      --alert-filter-regexp regexp.Regexp    alert names to ignore when checking for active alerts
+      --alert-firing-only bool               only consider firing alerts when checking for active alerts
+      --blocking-pod-selector stringArray    label selector identifying pods whose presence should prevent reboots
+      --drain-grace-period int               time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+      --skip-wait-for-delete-timeout int     when seconds is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
+      --ds-name string                       name of daemonset on which to place lock (default "kured")
+      --ds-namespace string                  namespace containing daemonset on which to place lock (default "kube-system")
+      --end-time string                      schedule reboot only before this time of day (default "23:59:59")
+      --force-reboot bool                    force a reboot even if the drain is still running (default: false)
+      --drain-timeout duration               timeout after which the drain is aborted (default: 0, infinite time)
+  -h, --help                                 help for kured
+      --label-with-exclude-from-external-lbs add "node.kubernetes.io/exclude-from-external-load-balancers" label to nodes undergoing kured reboot (default: false)
+      --lock-annotation string               annotation in which to record locking node (default "weave.works/kured-node-lock")
+      --lock-release-delay duration          hold lock after reboot by this duration (default: 0, disabled)
+      --lock-ttl duration                    expire lock annotation after this duration (default: 0, disabled)
+      --message-template-drain string        message template used to notify about a node being drained (default "Draining node %s")
+      --message-template-reboot string       message template used to notify about a node being rebooted (default "Rebooting node %s")
+      --notify-url                           url for reboot notifications (cannot use with --slack-hook-url flags)
+      --period duration                      reboot check period (default 1h0m0s)
+      --prefer-no-schedule-taint string      Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to "weave.works/kured-node-reboot" to enable tainting.
+      --prometheus-url string                Prometheus instance to probe for active alerts
+      --reboot-command string                command to run when a reboot is required by the sentinel (default "/sbin/systemctl reboot")
+      --reboot-days strings                  schedule reboot on these days (default [su,mo,tu,we,th,fr,sa])
+      --reboot-delay duration                add a delay after drain finishes but before the reboot command is issued (default 0, no time)
+      --reboot-sentinel string               path to file whose existence signals need to reboot (default "/var/run/reboot-required")
+      --reboot-sentinel-command string       command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
+      --slack-channel string                 slack channel for reboot notfications
+      --slack-hook-url string                slack hook URL for reboot notfications [deprecated in favor of --notify-url]
+      --slack-username string                slack username for reboot notfications (default "kured")
+      --start-time string                    schedule reboot only after this time of day (default "0:00")
+      --time-zone string                     use this timezone for schedule inputs (default "UTC")
+      --log-format string                    log format specified as text or json, defaults to "text"
 ```
 
 ### Reboot Sentinel File & Period

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -74,5 +74,6 @@ spec:
 #            - --end-time=23:59:59
 #            - --time-zone=UTC
 #            - --annotate-nodes=false
+#            - --label-with-exclude-from-external-lbs=false
 #            - --lock-release-delay=30m
 #            - --log-format=text


### PR DESCRIPTION
Previously, kured issued the system reboot command without first removing nodes from any connected external load balancers (ELBs).
    
This behavior caused downtime on restart because ELBs send traffic to kube-proxy pods running on nodes until the ELB health checks fail or the node is de-registered explicitly.
    
This patch solves the problem by adding a command line argument (`label-with-exclude-from-external-lbs`) that, when enabled, adds a "node.kubernetes.io/exclude-from-external-load-balancers" label to nodes undergoing kured reboot. This label tells the Kubernetes control plane to de-register the affected node from any connected ELBs. The node label is removed after restart which causes the control plane to re-register the node with the ELBs.

Close https://github.com/weaveworks/kured/issues/358