### PR TITLE
Change helm chart default value for updateStrategy to RollingUpdate

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.7.0"
 description: A Helm chart for kured
 name: kured
-version: 2.8.0
+version: 2.9.0
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -39,7 +39,7 @@ The following changes have been made compared to the stable chart:
 | `image.tag`             | Image tag                                                                   | `1.7.0`                    |
 | `image.pullPolicy`      | Image pull policy                                                           | `IfNotPresent`             |
 | `image.pullSecrets`     | Image pull secrets                                                          | `[]`                       |
-| `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |
+| `updateStrategy`        | Daemonset update strategy                                                   | `RollingUpdate`            |
 | `maxUnavailable`        | The max pods unavailable during a rolling update                            | `1`                        |
 | `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -4,7 +4,7 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
-updateStrategy: OnDelete
+updateStrategy: RollingUpdate
 #  requires RollingUpdate updateStrategy
 maxUnavailable: 1
 


### PR DESCRIPTION
This change sets the default value for the DaemonSet updateStrategy to RollingUpdate to automatically update kured Pods on every change of the DaemonSet spec.

Fixes #413