### PR TITLE
Exclude terminated pods from the blocking mechanism

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -284,7 +284,7 @@ func (pb PrometheusBlockingChecker) isBlocked() bool {
 }
 
 func (kb KubernetesBlockingChecker) isBlocked() bool {
-	fieldSelector := fmt.Sprintf("spec.nodeName=%s", kb.nodename)
+	fieldSelector := fmt.Sprintf("spec.nodeName=%s,status.phase!=Succeeded,status.phase!=Failed,status.phase!=Unknown", kb.nodename)
 	for _, labelSelector := range kb.filter {
 		podList, err := kb.client.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
 			LabelSelector: labelSelector,


### PR DESCRIPTION
Terminated pods should be excluded from the blocking a reboot as per https://github.com/weaveworks/kured/issues/227

This adds status filters to the fieldSelector in order to do that. I've not updated tests here but have successfully tested the exact same filter using kubectl