### PR TITLE
[WIP] ARM-Support

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -38,8 +38,10 @@ jobs:
 
       - name: Build image
         run: |
-          make DH_ORG="${{ github.repository_owner }}" image
+          make DH_ORG="${{ github.repository_owner }}" TARGETARCH="amd64" image
+          make DH_ORG="${{ github.repository_owner }}" TARGETARCH="arm64" image
 
       - name: Publish image
         run: |
-          make DH_ORG="${{ github.repository_owner }}" publish-image
+          make DH_ORG="${{ github.repository_owner }}" TARGETARCH="amd64" publish-image
+          make DH_ORG="${{ github.repository_owner }}" TARGETARCH="arm64" publish-image

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -26,7 +26,8 @@ jobs:
         run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
         id: tags
       - run: |
-          make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" image
+          make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" TARGETARCH="amd64" image
+          make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" TARGETARCH="arm64" image
       - uses: Azure/container-scan@v0
         with:
           image-name: docker.io/${{ github.repository_owner }}/kured:${{ steps.tags.outputs.version }}
@@ -46,4 +47,6 @@ jobs:
 
       - name: Publish image
         run: |
-          make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" publish-image
+          make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" TARGETARCH="amd64" publish-image
+          make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" TARGETARCH="arm64" publish-image
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-cmd/kured/kured
+cmd/kured/kured*
 vendor
 build

--- a/cmd/kured/Dockerfile
+++ b/cmd/kured/Dockerfile
@@ -1,4 +1,10 @@
 FROM alpine:3.15.0
+
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN apk update --no-cache && apk upgrade --no-cache && apk add --no-cache ca-certificates tzdata
-COPY ./kured /usr/bin/kured
+
+COPY ./kured_${TARGETOS}_${TARGETARCH} /usr/bin/kured
+
 ENTRYPOINT ["/usr/bin/kured"]


### PR DESCRIPTION
This is a WIP-PR of a build with ARM support.
I'm not really sure about the changes in the Makefile. With the changes for windows-support in mind from #460 this would create more and more complicated tooling-scripts to maintain.

My personal favourite is to do only the go-compilation and other small tasks in the makefile and move the image build and -publish to Github Actions which are already able to create multiarch-builds out of the box. But this would remove the ability to create images locally (without writing the commands on your own).

I also would suggest to not separate different architectures by image-tag and use the same tags for different arches.

WDYT?

Ref: #23