### PR TITLE
don't print env variable values in the logs (some are sensitive)

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -229,7 +229,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)
-			log.Infof("Binding %s command flag to environment variable: %s=%s", f.Name, flagToEnvVar(f.Name), fmt.Sprintf("%v", val))
+			log.Infof("Binding %s command flag to environment variable: %s", f.Name, flagToEnvVar(f.Name))
 			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
 		}
 	})


### PR DESCRIPTION
Happy new year friends!!! 👏🏼 🍾 😄 

While testing out v1.9.0, I realized I made a mistake in https://github.com/weaveworks/kured/pull/464 PR that prints in the log the value of the Environment Variables that are being bound to command flags, since some of these are sensitive (like `KURED_NOTIFY_URL`) we don't want their values to end up in the logs.

This PR addresses it, I think this is relatively important to merge in and perhaps worth cutting a v1.9.1 since currently it leaks sensitive details to the logs.

apologies for not catching this sooner.

/cc @ckotzbauer @evrardjp @jackfrancis (just tagging you folks for awareness as you've had the chance to review the original PR)