### PR TITLE
Add ability to define ds annotations in helm chart

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9.1"
 description: A Helm chart for kured
 name: kured
-version: 2.11.1
+version: 2.11.2
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -42,6 +42,7 @@ The following changes have been made compared to the stable chart:
 | `updateStrategy`        | Daemonset update strategy                                                   | `RollingUpdate`            |
 | `maxUnavailable`        | The max pods unavailable during a rolling update                            | `1`                        |
 | `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
+| `dsAnnotations`         | Annotations to apply to the kured DaemonSet                                 | `{}`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
 | `extraEnvVars`          | Array of environment variables to pass to the daemonset.                    | `{}`                       |
 | `configuration.lockTtl` | cli-parameter `--lock-ttl`                                                  | `0`                       |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
+  {{- if .Values.dsAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.dsAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   updateStrategy:
     type: {{ .Values.updateStrategy }}

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -9,6 +9,7 @@ updateStrategy: RollingUpdate
 maxUnavailable: 1
 
 podAnnotations: {}
+dsAnnotations: {}
 
 extraArgs: {}
 


### PR DESCRIPTION
Hi,
 this PR adds the ability to define custom annotations for the kured daemonset through the `dsAnnotations` helm value.

Value name and template syntax have been chosen to be similar to the already existing `podAnnotations`.

This covers our kured use case where during kured first setup all reboots are temporarily suspended by locking the daemonset using the annotation on the daemonset (ref. https://github.com/weaveworks/kured#disabling-reboots).