### PR TITLE
Helm chart: Use templating in Slack URL, channel and username

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9.1"
 description: A Helm chart for kured
 name: kured
-version: 2.11.3
+version: 2.12.0
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9.1"
 description: A Helm chart for kured
 name: kured
-version: 2.11.2
+version: 2.11.3
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -29,7 +29,7 @@ The following changes have been made compared to the stable chart:
 - Added support for affinities.
 - Configuration of cli-flags can be made through a `configuration` object.
 - Added optional `Service` and `ServiceMonitor` support for metrics endpoint.
-
+- Previously static Slack channel, hook URL and username values are now made dynamic using `tpl` function.
 
 ## Configuration
 
@@ -63,9 +63,9 @@ The following changes have been made compared to the stable chart:
 | `configuration.rebootSentinelCommand` | cli-parameter `--reboot-sentinel-command`                     | `""`                      |
 | `configuration.rebootCommand` | cli-parameter `--reboot-command`                                      | `""`                      |
 | `configuration.rebootDelay` | cli-parameter `--reboot-delay`                                          | `""`                      |
-| `configuration.slackChannel` | cli-parameter `--slack-channel`                                        | `""`                      |
-| `configuration.slackHookUrl` | cli-parameter `--slack-hook-url`                                       | `""`                      |
-| `configuration.slackUsername` | cli-parameter `--slack-username`                                      | `""`                      |
+| `configuration.slackChannel` | cli-parameter `--slack-channel`. Passed through `tpl`                  | `""`                      |
+| `configuration.slackHookUrl` | cli-parameter `--slack-hook-url`. Passed through `tpl`                 | `""`                      |
+| `configuration.slackUsername` | cli-parameter `--slack-username`. Passed through `tpl`                | `""`                      |
 | `configuration.notifyUrl` | cli-parameter `--notify-url`                                              | `""`                      |
 | `configuration.messageTemplateDrain` | cli-parameter `--message-template-drain`                       | `""`                      |
 | `configuration.messageTemplateReboot` | cli-parameter `--message-template-reboot`                     | `""`                      |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -113,13 +113,13 @@ spec:
             - --reboot-delay={{ .Values.configuration.rebootDelay }}
           {{- end }}
           {{- if .Values.configuration.slackChannel }}
-            - --slack-channel={{ .Values.configuration.slackChannel }}
+            - --slack-channel={{ tpl .Values.configuration.slackChannel . }}
           {{- end }}
           {{- if .Values.configuration.slackHookUrl }}
-            - --slack-hook-url={{ .Values.configuration.slackHookUrl }}
+            - --slack-hook-url={{ tpl .Values.configuration.slackHookUrl . }}
           {{- end }}
           {{- if .Values.configuration.slackUsername }}
-            - --slack-username={{ .Values.configuration.slackUsername }}
+            - --slack-username={{ tpl .Values.configuration.slackUsername . }}
           {{- end }}
           {{- if .Values.configuration.notifyUrl }}
             - --notify-url={{ .Values.configuration.notifyUrl }}


### PR DESCRIPTION
When running multiple clusters, user may want to route notifications to different Slack channels or use different Slack usernames when reporting Kured events from different clusters.

Allow for use of dynamic values with on-deployment templating by using `tpl` in Slack CLI parameters.