### PR TITLE
helm: ensure kured on 1.24 gets the correct toleration

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9.2"
 description: A Helm chart for kured
 name: kured
-version: 2.13.0
+version: 2.14.0
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/README.md
+++ b/charts/kured/README.md
@@ -92,7 +92,7 @@ The following changes have been made compared to the stable chart:
 | `service.annotations`   | Annotations to apply to the service (eg to add Prometheus annotations)      | `{}`                       |
 | `podLabels`             | Additional labels for pods (e.g. CostCenter=IT)                             | `{}`                       |
 | `priorityClassName`     | Priority Class to be used by the pods                                       | `""`                       |
-| `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)       | `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
+| `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)       | `[{"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule"}]` for Kubernetes 1.24.0 and greater, otherwise `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
 | `affinity`              | Affinity for the daemonset (ie, restrict which nodes kured runs on)         | `{}`                       |
 | `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)    | `{}`                       |
 | `volumeMounts`          | Maps of volumes mount to mount                                              | `{}`                       |

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -169,9 +169,19 @@ spec:
             {{- if .Values.extraEnvVars }}
               {{ toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
-      {{- with .Values.tolerations }}
       tolerations:
+      {{- if .Values.tolerations }}
+          {{- with .Values.tolerations }}
 {{ toYaml . | indent 8 }}
+          {{- end }}
+      {{- else }}
+          {{- if ge .Capabilities.KubeVersion.Minor "24" -}}
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+          {{- else }}
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kured/values.yaml
+++ b/charts/kured/values.yaml
@@ -87,9 +87,7 @@ podLabels: {}
 
 priorityClassName: ""
 
-tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+tolerations: []
 
 affinity: {}
 


### PR DESCRIPTION
This PR ensured that kured + k8s 1.24 is ready for changes to default control plane taint/toleration spec.

Rather than pass in the default tolerations via values.yaml, we use the built-in `.Capabilities` helm interface to determine at install time which tolerations to include by default.

If a user wishes to use configurable tolerations, this change respects that.

Fixes #538