### PR TITLE
ci: always use the latest golang patch version

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
       - name: run tests
         run: go test -json ./... > test.json
       - name: Annotate tests
@@ -48,7 +48,7 @@ jobs:
     - name: Ensure go version
       uses: actions/setup-go@v3
       with:
-        go-version: "${{ steps.awk_gomod.outputs.version }}"
+        go-version: "${{ steps.awk_gomod.outputs.version }}".x
     - name: Lint cmd folder
       uses: Jerome1337/golint-action@v1.0.2
       with:
@@ -87,7 +87,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
       - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
       - uses: Azure/container-scan@v0
         with:
@@ -119,7 +119,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
       - name: Build artifacts
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
@@ -190,7 +190,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
       - name: Build artifacts
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
@@ -281,7 +281,7 @@ jobs:
   #     - name: Ensure go version
   #       uses: actions/setup-go@v3
   #       with:
-  #         go-version: "${{ steps.awk_gomod.outputs.version }}"
+  #         go-version: "${{ steps.awk_gomod.outputs.version }}".x
   #     - name: Build artifacts
   #       run: |
   #         make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
       - name: Find current tag version
         run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
         id: tags

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
       - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
       - uses: Azure/container-scan@v0
         with:
@@ -87,7 +87,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.awk_gomod.outputs.version }}"
+          go-version: "${{ steps.awk_gomod.outputs.version }}".x
 
       - name: "Workaround 'Failed to attach 1 to compat systemd cgroup /actions_job/...' on gh actions"
         run: |


### PR DESCRIPTION
This PR adds a ".x" range suffix to the `go-version` configuration of `actions/setup-go@v3` to ensure that we always run CI with the latest available patch release of go.

For reference:

https://github.com/npm/node-semver#x-ranges-12x-1x-12-

Fixes #519