### PR TITLE
prune github actions

### DIFF
--- a/.github/workflows/on-pr-charts.yaml
+++ b/.github/workflows/on-pr-charts.yaml
@@ -47,16 +47,22 @@ jobs:
   deploy-chart:
     name: Functional test of helm chart in its current state (needs published image of the helm chart)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - "1.22"
+          - "1.23"
+          - "1.24"
     needs: test-chart
     steps:
       - uses: actions/checkout@v3
-      
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 1 node kind cluster
         uses: helm/kind-action@v1.2.0
         with:
+          config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
           version: v0.14.0
-
       - name: Deploy kured on default namespace with its helm chart
         run: |
           # Documented in official helm doc to live on the edge
@@ -67,7 +73,6 @@ jobs:
           kubectl config set-context kind-chart-testing
           kubectl get ds --all-namespaces
           kubectl describe ds kured
-
       - name: Test if successful deploy
         uses: nick-invision/retry@v2.7.0
         with:

--- a/.github/workflows/on-pr-charts.yaml
+++ b/.github/workflows/on-pr-charts.yaml
@@ -80,4 +80,4 @@ jobs:
           max_attempts: 10
           retry_wait_seconds: 10
           # DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE should all be = to cluster_size
-          command: "kubectl get ds kured | grep -E 'kured.*1.*1.*1.*1.*1'"
+          command: "kubectl get ds kured | grep -E 'kured.*5.*5.*5.*5.*5'"

--- a/.github/workflows/on-pr-charts.yaml
+++ b/.github/workflows/on-pr-charts.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Default name for helm/kind-action kind clusters is "chart-testing"
-      - name: Create 1 node kind cluster
+      - name: Create kind clusters
         uses: helm/kind-action@v1.2.0
         with:
           config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -124,6 +124,14 @@ jobs:
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" manifest
+      - name: Workaround "Failed to attach 1 to compat systemd cgroup /actions_job/..." on gh actions
+        run: |
+          sudo bash << EOF
+              cp /etc/docker/daemon.json /etc/docker/daemon.json.old
+              echo '{}' > /etc/docker/daemon.json
+              systemctl restart docker || journalctl --no-pager -n 500
+              systemctl status docker
+          EOF
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create kind cluster with 5 nodes
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -124,34 +124,20 @@ jobs:
         run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" manifest
-
-      - name: Workaround "Failed to attach 1 to compat systemd cgroup /actions_job/..." on gh actions
-        run: |
-          sudo bash << EOF
-              cp /etc/docker/daemon.json /etc/docker/daemon.json.old
-              echo '{}' > /etc/docker/daemon.json
-              systemctl restart docker || journalctl --no-pager -n 500
-              systemctl status docker
-          EOF
-
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create kind cluster with 5 nodes
         uses: helm/kind-action@v1.2.0
         with:
           config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
           version: v0.14.0
-
       - name: Preload previously built images onto kind cluster
         run: kind load docker-image docker.io/${{ github.repository_owner }}/kured:${{ github.sha }} --name chart-testing
-
       - name: Do not wait for an hour before detecting the rebootSentinel
         run: |
           sed -i 's/#\(.*\)--period=1h/\1--period=30s/g' kured-ds.yaml
-
       - name: Install kured with kubectl
         run: |
           kubectl apply -f kured-rbac.yaml && kubectl apply -f kured-ds.yaml
-
       - name: Ensure kured is ready
         uses: nick-invision/retry@v2.7.0
         with:
@@ -159,8 +145,7 @@ jobs:
           max_attempts: 10
           retry_wait_seconds: 60
           # DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE should all be = to cluster_size
-          command: "kubectl get ds -n kube-system kured | grep -E 'kured.*5.*5.*5.*5.*5'"
-
+          command: "kubectl get ds kured | grep -E 'kured.*5.*5.*5.*5.*5'"
       - name: Create reboot sentinel files
         run: |
           ./tests/kind/create-reboot-sentinels.sh
@@ -170,7 +155,6 @@ jobs:
           DEBUG: true
         run: |
           ./tests/kind/follow-coordinated-reboot.sh
-
   scenario-prom-helm:
     name: Test prometheus with latest code from HEAD (=overrides image of the helm chart)
     runs-on: ubuntu-latest
@@ -204,16 +188,13 @@ jobs:
               systemctl restart docker || journalctl --no-pager -n 500
               systemctl status docker
           EOF
-
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 1 node kind cluster
         uses: helm/kind-action@v1.2.0
         with:
           version: v0.14.0
-
       - name: Preload previously built images onto kind cluster
         run: kind load docker-image docker.io/${{ github.repository_owner }}/kured:${{ github.sha }} --name chart-testing
-
       - name: Deploy kured on default namespace with its helm chart
         run: |
           # Documented in official helm doc to live on the edge
@@ -224,7 +205,6 @@ jobs:
           kubectl config set-context kind-chart-testing
           kubectl get ds --all-namespaces
           kubectl describe ds kured
-
       - name: Ensure kured is ready
         uses: nick-invision/retry@v2.7.0
         with:

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -84,6 +84,14 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.awk_gomod.outputs.version }}.x"
+      - name: "Workaround 'Failed to attach 1 to compat systemd cgroup /actions_job/...' on gh actions"
+        run: |
+          sudo bash << EOF
+              cp /etc/docker/daemon.json /etc/docker/daemon.json.old
+              echo '{}' > /etc/docker/daemon.json
+              systemctl restart docker || journalctl --no-pager -n 500
+              systemctl status docker
+          EOF
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 5 node kind cluster
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -18,7 +18,6 @@ jobs:
         uses: guyarb/golang-test-annoations@v0.5.1
         with:
           test-results: test.json
-
   periodics-mark-stale:
     name: Mark stale issues and PRs
     runs-on: ubuntu-latest
@@ -34,7 +33,6 @@ jobs:
         stale-pr-label: 'no-pr-activity'
         exempt-issue-labels: 'good first issue,keep'
         days-before-close: 21
-
   check-docs-links:
     name: Check docs for incorrect links
     runs-on: ubuntu-latest
@@ -47,7 +45,6 @@ jobs:
         args: -r *.md *.yaml */*/*.go -x .cluster.local
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}
-
   vuln-scan:
     name: Build image and scan it against known vulnerabilities
     runs-on: ubuntu-latest
@@ -66,7 +63,6 @@ jobs:
       - uses: Azure/container-scan@v0
         with:
           image-name: docker.io/${{ github.repository_owner }}/kured:${{ github.sha }}
-
   deploy-helm:
     name: Ensure our currently released helm chart works on all kubernetes versions
     runs-on: ubuntu-latest
@@ -88,23 +84,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.awk_gomod.outputs.version }}.x"
-
-      - name: "Workaround 'Failed to attach 1 to compat systemd cgroup /actions_job/...' on gh actions"
-        run: |
-          sudo bash << EOF
-              cp /etc/docker/daemon.json /etc/docker/daemon.json.old
-              echo '{}' > /etc/docker/daemon.json
-              systemctl restart docker || journalctl --no-pager -n 500
-              systemctl status docker
-          EOF
-
       # Default name for helm/kind-action kind clusters is "chart-testing"
       - name: Create 5 node kind cluster
         uses: helm/kind-action@v1.2.0
         with:
           config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
           version: v0.14.0
-
       - name: Deploy kured on default namespace with its helm chart
         run: |
           # Documented in official helm doc to live on the edge
@@ -117,7 +102,6 @@ jobs:
           kubectl get nodes -o yaml
           sleep 5
           kubectl describe ds kured
-
       - name: Ensure kured is ready
         uses: nick-invision/retry@v2.7.0
         with:
@@ -126,11 +110,9 @@ jobs:
           retry_wait_seconds: 60
           # DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE should all be = 5
           command: "kubectl get ds kured | grep -E 'kured.*5.*5.*5.*5.*5' "
-
       - name: Create reboot sentinel files
         run: |
           ./tests/kind/create-reboot-sentinels.sh
-
       - name: Follow reboot until success
         env:
           DEBUG: true

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -3,13 +3,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kured
-  namespace: kube-system
+  namespace: default
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kured            # Must match `--ds-name`
-  namespace: kube-system # Must match `--ds-namespace`
+  namespace: default # Must match `--ds-namespace`
 spec:
   selector:
     matchLabels:
@@ -51,7 +51,7 @@ spec:
 #            - --skip-wait-for-delete-timeout=0
 #            - --drain-timeout=0
 #            - --period=1h
-#            - --ds-namespace=kube-system
+#            - --ds-namespace=default
 #            - --ds-name=kured
 #            - --lock-annotation=weave.works/kured-node-lock
 #            - --lock-ttl=0


### PR DESCRIPTION
This PR removes an old docker workaround, and standardizes kured daemonset lookups to use the "default" namespace (where it's actually installed).