### PR TITLE
tolerate both 1.24+ and prior control plane taints

### DIFF
--- a/charts/kured/Chart.yaml
+++ b/charts/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9.2"
 description: A Helm chart for kured
 name: kured
-version: 2.14.1
+version: 2.14.2
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: ckotzbauer

--- a/charts/kured/templates/daemonset.yaml
+++ b/charts/kured/templates/daemonset.yaml
@@ -175,13 +175,10 @@ spec:
 {{ toYaml . | indent 8 }}
           {{- end }}
       {{- else }}
-          {{- if ge .Capabilities.KubeVersion.Minor "24" }}
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          {{- else }}
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
This PR update daemonset tolerations so that both pre and 1.24+ taints are tolerated.

Fixes #556