### PR TITLE
improved documentation covering slack usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,10 @@ Alternatively you can use the `--message-template-drain` and `--message-template
 Here is the syntax:
 
 - slack:           `slack://tokenA/tokenB/tokenC`
-(`--slack-hook-url` is deprecated but possible to use)
+
+    (`slack://<USERNAME>@tokenA/tokenB/tokenC` - in case you want to [respect username](https://github.com/weaveworks/kured/issues/482))
+
+    (`--slack-hook-url` is deprecated but possible to use)
 
 - rocketchat:      `rocketchat://[username@]rocketchat-host/token[/channel|@recipient]`
 


### PR DESCRIPTION
 This PR clarrifies how user can use --notify
 -url flag and respect the username by adding
 <username>@ in front of tokenA.

* Tested the syntax: slack://username@tokenA/tokenB/tokenC on a kind k8s cluster with kured as addon + a slack channel. 
```
          command:
            - /usr/bin/kured
            - --notify-url=slack://kured-bot@<token>/<token>/<token>
            - --period=20s
```
```
[kured-bot](https://app.slack.com/team/B01F49PD9EV)APP  
[3:23 PM](https://kured-tesing-personal.slack.com/archives/C01ERSH2PFD/p1653571403864349)
Draining node kind-worker2
[3:23](https://kured-tesing-personal.slack.com/archives/C01ERSH2PFD/p1653571404102789)
Rebooting node kind-worker2
```
