### PR TITLE
updated slack-related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ Here is the syntax:
 
     (`--slack-hook-url` is deprecated but possible to use)
 
+  For the new slack App integration, use:\
+    `slack://xoxb:123456789012-1234567890123-4mt0t4l1YL3g1T5L4cK70k3N@<CHANNEL_NAME>?botname=<BOTNAME>`\
+    for more information, [look here](https://containrrr.dev/shoutrrr/v0.5/services/slack/#examples)
+
 - rocketchat:      `rocketchat://[username@]rocketchat-host/token[/channel|@recipient]`
 
 - teams:           `teams://group@tenant/altId/groupOwner?host=organization.webhook.office.com`


### PR DESCRIPTION
 since slack has implemented their new
 way of authenticating apps, checked if
 shoutrrr did cover that and tested the
 implementation on a slack channel.
 
 Tested on slack channel:
 ```
[kured-bot](https://app.slack.com/team/U03HGDTR8U9)APP  [1:21 PM](https://kured-tesing-personal.slack.com/archives/C01ERSH2PFD/p1653736871547619)
aaaa
```