### PR TITLE
added notification when uncordoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Flags:
       --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
       --lock-release-delay duration         hold lock after reboot by this duration (default: 0, disabled)
       --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
+      --message-template-uncordon string    message template used to notify about a node being successfully uncordoned (default "Node %s rebooted & uncordoned successfully!")
       --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
       --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
       --notify-url                          url for reboot notifications (cannot use with --slack-hook-url flags)
@@ -275,7 +276,7 @@ about draining and rebooting nodes across a list of technologies.
 
 ![Notification](img/slack-notification.png)
 
-Alternatively you can use the `--message-template-drain` and `--message-template-reboot` to customize the text of the message, e.g.
+Alternatively you can use the `--message-template-drain`, `--message-template-reboot` and `--message-template-uncordon` to customize the text of the message, e.g.
 
 ```cli
 --message-template-drain="Draining node %s part of *my-cluster* in region *xyz*"

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -66,6 +66,7 @@ var (
 	slackChannel                    string
 	messageTemplateDrain            string
 	messageTemplateReboot           string
+	messageTemplateUncordon         string
 	podSelectors                    []string
 	rebootCommand                   string
 	logFormat                       string
@@ -166,6 +167,8 @@ func NewRootCommand() *cobra.Command {
 		"slack channel for reboot notfications")
 	rootCmd.PersistentFlags().StringVar(&notifyURL, "notify-url", "",
 		"notify URL for reboot notfications")
+	rootCmd.PersistentFlags().StringVar(&messageTemplateUncordon, "message-template-uncordon", "Node %s rebooted & uncordoned successfully!",
+		"message template used to notify about a node being successfully uncordoned")
 	rootCmd.PersistentFlags().StringVar(&messageTemplateDrain, "message-template-drain", "Draining node %s",
 		"message template used to notify about a node being drained")
 	rootCmd.PersistentFlags().StringVar(&messageTemplateReboot, "message-template-reboot", "Rebooting node %s",
@@ -637,7 +640,7 @@ func rebootAsRequired(nodeID string, rebootCommand []string, sentinelCommand []s
 					continue
 				} else {
 					if notifyURL != "" {
-						if err := shoutrrr.Send(notifyURL, fmt.Sprintf("Node: %s rebooted & uncordoned successfully!", nodeID)); err != nil {
+						if err := shoutrrr.Send(notifyURL, fmt.Sprintf(messageTemplateUncordon, nodeID)); err != nil {
 							log.Warnf("Error notifying: %v", err)
 						}
 					}

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -635,6 +635,12 @@ func rebootAsRequired(nodeID string, rebootCommand []string, sentinelCommand []s
 				if err != nil {
 					log.Errorf("Unable to uncordon %s: %v, will continue to hold lock and retry uncordon", node.GetName(), err)
 					continue
+				} else {
+					if notifyURL != "" {
+						if err := shoutrrr.Send(notifyURL, fmt.Sprintf("Node: %s rebooted & uncordoned successfully!", nodeID)); err != nil {
+							log.Warnf("Error notifying: %v", err)
+						}
+					}
 				}
 			}
 			// If we're holding the lock we know we've tried, in a prior run, to reboot


### PR DESCRIPTION
 when reboot & uncordoning is successful -> notification will be sent.
 Fixes: https://github.com/weaveworks/kured/issues/585
 
AFTER:
```
[kured-bot](https://app.slack.com/team)
APP  
[1:26 PM](https://kured-tesing-personal.slack.com/archives)
Draining node kind-worker2
[1:26](https://kured-tesing-personal.slack.com/archives)
Rebooting node kind-worker2
[1:27](https://kured-tesing-personal.slack.com/archives)
Node: kind-worker2 rebooted&uncordoned successfully!
```