### PR TITLE
ci: address Azure/container-scan regression

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -90,6 +90,9 @@ jobs:
           go-version: "${{ steps.awk_gomod.outputs.version }}.x"
       - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
       - uses: Azure/container-scan@v0
+        env:
+          # See https://github.com/goodwithtech/dockle/issues/188
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
         with:
           image-name: docker.io/${{ github.repository_owner }}/kured:${{ github.sha }}
 

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -28,6 +28,9 @@ jobs:
       - run: |
           make DH_ORG="${{ github.repository_owner }}" VERSION="${{ steps.tags.outputs.version }}" image
       - uses: Azure/container-scan@v0
+        env:
+          # See https://github.com/goodwithtech/dockle/issues/188
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
         with:
           image-name: docker.io/${{ github.repository_owner }}/kured:${{ steps.tags.outputs.version }}
 

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -64,6 +64,9 @@ jobs:
           go-version: "${{ steps.awk_gomod.outputs.version }}.x"
       - run: make DH_ORG="${{ github.repository_owner }}" VERSION="${{ github.sha }}" image
       - uses: Azure/container-scan@v0
+        env:
+          # See https://github.com/goodwithtech/dockle/issues/188
+          DOCKLE_HOST: "unix:///var/run/docker.sock"
         with:
           image-name: docker.io/${{ github.repository_owner }}/kured:${{ github.sha }}
 


### PR DESCRIPTION
This PR addresses the failing CI job `Azure/container-scan` which we use to validate the images we use in testing and building kured. This workaround follows the recommendation here:

https://github.com/Azure/container-scan/issues/146#issue-1293213052

Fixes #597