### PR TITLE
update command line flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,39 +88,48 @@ edit it in accordance with the following section before application.
 The following arguments can be passed to kured via the daemonset pod template:
 
 ```console
+Kubernetes Reboot Daemon
+
+Usage:
+  kured [flags]
+
 Flags:
       --alert-filter-regexp regexp.Regexp   alert names to ignore when checking for active alerts
-      --alert-firing-only bool              only consider firing alerts when checking for active alerts
+      --alert-firing-only                   only consider firing alerts when checking for active alerts
+      --annotate-nodes                      if set, the annotations 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' will be given to nodes undergoing kured reboots
       --blocking-pod-selector stringArray   label selector identifying pods whose presence should prevent reboots
-      --drain-grace-period int              time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
-      --skip-wait-for-delete-timeout int    when seconds is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
+      --drain-grace-period int              time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default -1)
+      --drain-timeout duration              timeout after which the drain is aborted (default: 0, infinite time)
       --ds-name string                      name of daemonset on which to place lock (default "kured")
       --ds-namespace string                 namespace containing daemonset on which to place lock (default "kube-system")
       --end-time string                     schedule reboot only before this time of day (default "23:59:59")
-      --force-reboot bool                   force a reboot even if the drain is still running (default: false)
-      --drain-timeout duration              timeout after which the drain is aborted (default: 0, infinite time)
+      --force-reboot                        force a reboot even if the drain fails or times out
   -h, --help                                help for kured
       --lock-annotation string              annotation in which to record locking node (default "weave.works/kured-node-lock")
-      --lock-release-delay duration         hold lock after reboot by this duration (default: 0, disabled)
+      --lock-release-delay duration         delay lock release for this duration (default: 0, disabled)
       --lock-ttl duration                   expire lock annotation after this duration (default: 0, disabled)
-      --message-template-uncordon string    message template used to notify about a node being successfully uncordoned (default "Node %s rebooted & uncordoned successfully!")
+      --log-format string                   use text or json log format (default "text")
       --message-template-drain string       message template used to notify about a node being drained (default "Draining node %s")
       --message-template-reboot string      message template used to notify about a node being rebooted (default "Rebooting node %s")
-      --notify-url                          url for reboot notifications (cannot use with --slack-hook-url flags)
-      --period duration                     reboot check period (default 1h0m0s)
+      --message-template-uncordon string    message template used to notify about a node being successfully uncordoned (default "Node %s rebooted & uncordoned successfully!")
+      --node-id string                      node name kured runs on, should be passed down from spec.nodeName via KURED_NODE_ID environment variable
+      --notify-url string                   notify URL for reboot notifications (cannot use with --slack-hook-url flags)
+      --period duration                     sentinel check period (default 1h0m0s)
+      --post-reboot-node-labels strings     labels to add to nodes after uncordoning
+      --pre-reboot-node-labels strings      labels to add to nodes before cordoning
       --prefer-no-schedule-taint string     Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to "weave.works/kured-node-reboot" to enable tainting.
       --prometheus-url string               Prometheus instance to probe for active alerts
-      --reboot-command string               command to run when a reboot is required by the sentinel (default "/sbin/systemctl reboot")
+      --reboot-command string               command to run when a reboot is required (default "/bin/systemctl reboot")
       --reboot-days strings                 schedule reboot on these days (default [su,mo,tu,we,th,fr,sa])
-      --reboot-delay duration               add a delay after drain finishes but before the reboot command is issued (default 0, no time)
-      --reboot-sentinel string              path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-      --reboot-sentinel-command string      command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
-      --slack-channel string                slack channel for reboot notfications
-      --slack-hook-url string               slack hook URL for reboot notfications [deprecated in favor of --notify-url]
-      --slack-username string               slack username for reboot notfications (default "kured")
+      --reboot-delay duration               delay reboot for this duration (default: 0, disabled)
+      --reboot-sentinel string              path to file whose existence triggers the reboot command (default "/var/run/reboot-required")
+      --reboot-sentinel-command string      command for which a zero return code will trigger a reboot command
+      --skip-wait-for-delete-timeout int    when seconds is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node
+      --slack-channel string                slack channel for reboot notifications
+      --slack-hook-url string               slack hook URL for reboot notifications [deprecated in favor of --notify-url]
+      --slack-username string               slack username for reboot notifications (default "kured")
       --start-time string                   schedule reboot only after this time of day (default "0:00")
       --time-zone string                    use this timezone for schedule inputs (default "UTC")
-      --log-format string                   log format specified as text or json, defaults to "text"
 ```
 
 ### Reboot Sentinel File & Period

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -123,11 +123,11 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&nodeID, "node-id", "",
 		"node name kured runs on, should be passed down from spec.nodeName via KURED_NODE_ID environment variable")
 	rootCmd.PersistentFlags().BoolVar(&forceReboot, "force-reboot", false,
-		"force a reboot even if the drain fails or times out (default: false)")
+		"force a reboot even if the drain fails or times out")
 	rootCmd.PersistentFlags().IntVar(&drainGracePeriod, "drain-grace-period", -1,
-		"time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)")
+		"time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used")
 	rootCmd.PersistentFlags().IntVar(&skipWaitForDeleteTimeoutSeconds, "skip-wait-for-delete-timeout", 0,
-		"when seconds is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)")
+		"when seconds is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node")
 	rootCmd.PersistentFlags().DurationVar(&drainTimeout, "drain-timeout", 0,
 		"timeout after which the drain is aborted (default: 0, infinite time)")
 	rootCmd.PersistentFlags().DurationVar(&rebootDelay, "reboot-delay", 0,
@@ -149,7 +149,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().Var(&regexpValue{&alertFilter}, "alert-filter-regexp",
 		"alert names to ignore when checking for active alerts")
 	rootCmd.PersistentFlags().BoolVar(&alertFiringOnly, "alert-firing-only", false,
-		"only consider firing alerts when checking for active alerts (default: false)")
+		"only consider firing alerts when checking for active alerts")
 	rootCmd.PersistentFlags().StringVar(&rebootSentinelFile, "reboot-sentinel", "/var/run/reboot-required",
 		"path to file whose existence triggers the reboot command")
 	rootCmd.PersistentFlags().StringVar(&preferNoScheduleTaintName, "prefer-no-schedule-taint", "",
@@ -160,13 +160,13 @@ func NewRootCommand() *cobra.Command {
 		"command to run when a reboot is required")
 
 	rootCmd.PersistentFlags().StringVar(&slackHookURL, "slack-hook-url", "",
-		"slack hook URL for notifications")
+		"slack hook URL for reboot notifications [deprecated in favor of --notify-url]")
 	rootCmd.PersistentFlags().StringVar(&slackUsername, "slack-username", "kured",
-		"slack username for notifications")
+		"slack username for reboot notifications")
 	rootCmd.PersistentFlags().StringVar(&slackChannel, "slack-channel", "",
-		"slack channel for reboot notfications")
+		"slack channel for reboot notifications")
 	rootCmd.PersistentFlags().StringVar(&notifyURL, "notify-url", "",
-		"notify URL for reboot notfications")
+		"notify URL for reboot notifications (cannot use with --slack-hook-url flags)")
 	rootCmd.PersistentFlags().StringVar(&messageTemplateUncordon, "message-template-uncordon", "Node %s rebooted & uncordoned successfully!",
 		"message template used to notify about a node being successfully uncordoned")
 	rootCmd.PersistentFlags().StringVar(&messageTemplateDrain, "message-template-drain", "Draining node %s",


### PR DESCRIPTION
This PR updates the `README.md` command line flags content with the latest output from `go run cmd/kured/main.go --help`.

Issue #603 identified that the README was out of date.

Also sanitized the cobra command definitions a bit for better presentation, and incorporated some additional manual language that had been added to the `README.md`, but not the actual code.