### PR TITLE
Update maintainer email address

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,5 @@
 Christian Kotzbauer <christian.kotzbauer@gmail.com> (@ckotzbauer)
 Daniel Holbach <daniel@weave.works> (@dholbach)
 Hidde Beydals <hidde@weave.works> (@hiddeco)
-Jean-Phillipe Evrard <jean-philippe.evrard@suse.com> (@evrardjp)
+Jean-Philippe Evrard <open-source@a.spamming.party> (@evrardjp)
 Jack Francis <jackfrancis@gmail.com> (@jackfrancis)


### PR DESCRIPTION
My maintainer email address is outdated, and is not
redirected anymore. This should fix it.

Signed-off-by: Jean-Philippe Evrard <open-source@a.spamming.party>
